### PR TITLE
Fix support for ipv6 loopback address

### DIFF
--- a/.kokoro/tests/run_tests.sh
+++ b/.kokoro/tests/run_tests.sh
@@ -16,6 +16,12 @@
 # `-e` enables the script to automatically fail when a command fails
 set -e
 
+# Ensure both ipv4 and ipv6 functionality is tested.
+#
+# Tests will fail if the environment doesn't support both nets and it means we
+# need to find a test env that supports both.
+export EXPECT_IPV4_AND_IPV6=true
+
 # Re-organize files into proper Go format
 export GOPATH=$PWD/gopath
 target=$GOPATH/src/github.com/GoogleCloudPlatform

--- a/cmd/cloud_sql_proxy/proxy.go
+++ b/cmd/cloud_sql_proxy/proxy.go
@@ -180,7 +180,7 @@ type instanceConfig struct {
 // valid loopback address for "tcp".
 var loopbackForNet = map[string]string{
 	"tcp4": "127.0.0.1",
-	"tcp6": "[::1]",
+	"tcp6": "::1",
 }
 
 // validNets tracks the networks that are valid for this platform and machine.
@@ -191,13 +191,13 @@ var validNets = func() map[string]bool {
 
 	anyTCP := false
 	for _, n := range []string{"tcp4", "tcp6"} {
-		addr, ok := loopbackForNet[n]
+		host, ok := loopbackForNet[n]
 		if !ok {
 			// This is effectively a compile-time error.
 			panic(fmt.Sprintf("no loopback address found for %v", n))
 		}
 		// Open any port to see if the net is valid.
-		x, err := net.Listen(n, addr+":0")
+		x, err := net.Listen(n, net.JoinHostPort(host, "0"))
 		if err != nil {
 			// Error is too verbose to be useful.
 			continue
@@ -210,7 +210,7 @@ var validNets = func() map[string]bool {
 			// Set the loopback value for generic tcp if it hasn't already been
 			// set. (If both tcp4/tcp6 are supported the first one in the list
 			// (tcp4's 127.0.0.1) is used.
-			loopbackForNet["tcp"] = addr
+			loopbackForNet["tcp"] = host
 		}
 	}
 	if anyTCP {

--- a/cmd/cloud_sql_proxy/proxy_test.go
+++ b/cmd/cloud_sql_proxy/proxy_test.go
@@ -16,9 +16,11 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"io/ioutil"
 	"net"
 	"net/http"
+	"os"
 	"testing"
 )
 
@@ -96,77 +98,100 @@ func TestCreateInstanceConfigs(t *testing.T) {
 }
 
 func TestParseInstanceConfig(t *testing.T) {
-	for _, v := range []struct {
+	// sentinel values
+	var (
+		anyLoopbackAddress = "<any loopback address>"
+		wantErr            = instanceConfig{"<want error>", "", ""}
+	)
+
+	tcs := []struct {
 		// inputs
 		dir, instance string
 
-		wantCfg               instanceConfig
-		wantErr, wantLoopback bool
+		wantCfg instanceConfig
 	}{
 		{
 			"/x", "domain.com:my-proj:my-reg:my-instance",
 			instanceConfig{"domain.com:my-proj:my-reg:my-instance", "unix", "/x/domain.com:my-proj:my-reg:my-instance"},
-			false, false,
 		}, {
 			"/x", "my-proj:my-reg:my-instance",
 			instanceConfig{"my-proj:my-reg:my-instance", "unix", "/x/my-proj:my-reg:my-instance"},
-			false, false,
 		}, {
 			"/x", "my-proj:my-reg:my-instance=unix:socket_name",
 			instanceConfig{"my-proj:my-reg:my-instance", "unix", "/x/socket_name"},
-			false, false,
 		}, {
 			"/x", "my-proj:my-reg:my-instance=unix:/my/custom/sql-socket",
 			instanceConfig{"my-proj:my-reg:my-instance", "unix", "/my/custom/sql-socket"},
-			false, false,
 		}, {
 			"/x", "my-proj:my-reg:my-instance=tcp:1234",
-			instanceConfig{"my-proj:my-reg:my-instance", "tcp", "[::1]:1234"},
-			false, true,
+			instanceConfig{"my-proj:my-reg:my-instance", "tcp", anyLoopbackAddress},
+		}, {
+			"/x", "my-proj:my-reg:my-instance=tcp4:1234",
+			instanceConfig{"my-proj:my-reg:my-instance", "tcp4", "127.0.0.1:1234"},
+		}, {
+			"/x", "my-proj:my-reg:my-instance=tcp6:1234",
+			instanceConfig{"my-proj:my-reg:my-instance", "tcp6", "[::1]:1234"},
 		}, {
 			"/x", "my-proj:my-reg:my-instance=tcp:my-host:1111",
 			instanceConfig{"my-proj:my-reg:my-instance", "tcp", "my-host:1111"},
-			false, false,
 		}, {
 			"/x", "my-proj:my-reg:my-instance=",
-			instanceConfig{},
-			true, false,
+			wantErr,
 		}, {
 			"/x", "my-proj:my-reg:my-instance=cool network",
-			instanceConfig{},
-			true, false,
+			wantErr,
 		}, {
 			"/x", "my-proj:my-reg:my-instance=cool network:1234",
-			instanceConfig{},
-			true, false,
+			wantErr,
 		}, {
 			"/x", "my-proj:my-reg:my-instance=oh:so:many:colons",
-			instanceConfig{},
-			true, false,
+			wantErr,
 		},
-	} {
-		got, err := parseInstanceConfig(v.dir, v.instance, mockClient)
-		if v.wantErr {
-			if err == nil {
-				t.Errorf("parseInstanceConfig(%s, %s) = %+v, wanted error", v.dir, v.instance, got)
+	}
+
+	for _, tc := range tcs {
+		t.Run(fmt.Sprintf("parseInstanceConfig(%q, %q)", tc.dir, tc.instance), func(t *testing.T) {
+			if os.Getenv("EXPECT_IPV4_AND_IPV6") != "true" {
+				// Skip ipv4 and ipv6 if they are not supported by the machine.
+				// (assumption is that validNets isn't buggy)
+				switch tc.wantCfg.Network {
+				case "tcp4":
+				case "tcp6":
+					if !validNets[tc.wantCfg.Network] {
+						t.Skipf("%q net not supported, skipping", tc.wantCfg.Network)
+					}
+				}
 			}
-			continue
-		} else if err != nil {
-			t.Errorf("parseInstanceConfig(%s, %s) had unexpected error: %v", v.dir, v.instance, err)
-			continue
-		}
-		if got != v.wantCfg {
-			if v.wantLoopback {
+
+			got, err := parseInstanceConfig(tc.dir, tc.instance, mockClient)
+			if tc.wantCfg == wantErr {
+				if err != nil {
+					return // pass. an error was expected and returned.
+				}
+				t.Fatalf("parseInstanceConfig(%s, %s) = %+v, wanted error", tc.dir, tc.instance, got)
+			}
+			if err != nil {
+				t.Fatalf("parseInstanceConfig(%s, %s) had unexpected error: %v", tc.dir, tc.instance, err)
+			}
+
+			if tc.wantCfg.Address == anyLoopbackAddress {
 				host, _, err := net.SplitHostPort(got.Address)
 				if err != nil {
-					t.Errorf("parseInstanceConfig(%s, %s) = %+v, want %+v", v.dir, v.instance, got, v.wantCfg)
+					t.Fatalf("net.SplitHostPort(%v): %v", got.Address, err)
 				}
 				ip := net.ParseIP(host)
-				if ip.IsLoopback() {
-					continue
+				if !ip.IsLoopback() {
+					t.Fatalf("want loopback, got addr: %v", got.Address)
 				}
+
+				// use a placeholder address, so the rest of the config can be compared
+				got.Address = "<loopback>"
+				tc.wantCfg.Address = got.Address
 			}
-			t.Errorf("parseInstanceConfig(%s, %s) = %+v, want %+v", v.dir, v.instance, got, v.wantCfg)
-		}
+
+			if got != tc.wantCfg {
+				t.Errorf("parseInstanceConfig(%s, %s) = %+v, want %+v", tc.dir, tc.instance, got, tc.wantCfg)
+			}
+		})
 	}
 }


### PR DESCRIPTION
PR #289 broke this support by using net.JoinHostPort, which wraps a v6
address in square brackets, e.g. [::1]

This resulted in a double-wrapping - the resultant address was something
like "[[::1]]:3306".

Also add tests explicitly for listening on the "tcp4" and "tcp6" nets.