### PR TITLE
fix: fail fast on invalid config

### DIFF
--- a/proxy/proxy/client_test.go
+++ b/proxy/proxy/client_test.go
@@ -560,4 +560,24 @@ func TestClientHandshakeCanceled(t *testing.T) {
 		})
 	})
 
+	// Fail fast when dial attempts trigger a race condition
+	t.Run("dialing in quick succession", func(t *testing.T) {
+		withTestHarness(t, func(port int) {
+			c := newClient(port)
+
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+
+			var ok bool
+			for i := 0; i < 100; i++ {
+				_, err := c.DialContext(ctx, instance)
+				if err == ErrUnexpectedFailure {
+					ok = true
+				}
+			}
+			if !ok {
+				t.Fatal("wanted ErrUnexpectedFailure, got none")
+			}
+		})
+	})
 }


### PR DESCRIPTION
When multiple dial attempts start in quick succession and one attempt
fails on a handshake error, it can cause other attempts to see invalid
config. Rather than fix the underlying race condition in the refresh
logic (work completed in the upcoming v2 release), this commit provides
a quick fix and ensures connection attempts fail fast on bad config.

Fixes #997.