### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ To install from source, ensure you have the latest version of [Go installed](htt
 Then, simply run:
 
 ```shell
-go install github.com/GoogleCloudPlatform/cloud-sql-proxy@latest
+go install github.com/GoogleCloudPlatform/cloud-sql-proxy/v2@latest
 ```
 
 The `cloud-sql-proxy` will be placed in `$GOPATH/bin` or `$HOME/go/bin`.


### PR DESCRIPTION
## Change Description

Fix README.md, because when performing this command,

```bash
go install github.com/GoogleCloudPlatform/cloud-sql-proxy@latest    
```

I get

```
go: github.com/GoogleCloudPlatform/cloud-sql-proxy@latest: module github.com/GoogleCloudPlatform/cloud-sql-proxy@latest found (v1.31.2), but does not contain package github.com/GoogleCloudPlatform/cloud-sql-proxy
```

Suffixing with `/v2` works.