### PR TITLE
Allow for project & region discovery

### DIFF
--- a/cmd/cloud_sql_proxy/cloud_sql_proxy_test.go
+++ b/cmd/cloud_sql_proxy/cloud_sql_proxy_test.go
@@ -23,7 +23,7 @@ import (
 func TestVersionStripsNewline(t *testing.T) {
 	v, err := os.ReadFile("version.txt")
 	if err != nil {
-		t.Fatalf("failed to read verion.txt: %v", err)
+		t.Fatalf("failed to read version.txt: %v", err)
 	}
 	want := strings.TrimSpace(string(v))
 


### PR DESCRIPTION
## Change Description

We have a usecase in which we have multiple CloudSQL instances across various regions, in which we never want to have cross region communications.
Currently when using `-dir` and `-project` we have an all or nothing approach.

With the changes proposed here, we are then able to scope project & region as a limiting factor, only creating sockets for those CloudSQL instances within the region in which cloudsql-proxy is running within.

## Checklist

- [ ] Make sure to open an issue as a 
  [bug/issue](https://github.com/GoogleCloudPlatform/cloudsql-proxy/issues/new/choose) 
  before writing your code!  That way we can discuss the change, evaluate 
  designs, and agree on the general idea.
- [x] Ensure the tests and linter pass
- [x] Appropriate documentation is updated (if necessary)

