### PR TITLE
chore: configure pipefail to catch failures

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -119,6 +119,7 @@ jobs:
           SQLSERVER_DB: '${{ steps.secrets.outputs.SQLSERVER_DB }}'
           TMPDIR: "/tmp"
           TMP: '${{ runner.temp }}'
+        # specifying bash shell ensures a failure in a piped process isn't lost by using `set -eo pipefail`
         shell: bash
         run: |
           go install github.com/jstemmer/go-junit-report/v2@latest

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -136,7 +136,7 @@ jobs:
 
       - name: FlakyBot (Windows)
         # only run flakybot on periodic (schedule) and continuous (push) events
-        if: ${{ (github.event_name == 'pull_request' || github.event_name == 'push') && runner.os == 'Windows' && always() }}
+        if: ${{ (github.event_name == 'schedule' || github.event_name == 'push') && runner.os == 'Windows' && always() }}
         run: |
           curl https://github.com/googleapis/repo-automation-bots/releases/download/flakybot-1.1.0/flakybot.exe -o flakybot.exe -s -L
           ./flakybot.exe --repo ${{github.repository}} --commit_hash ${{github.sha}} --build_url https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -136,7 +136,7 @@ jobs:
 
       - name: FlakyBot (Windows)
         # only run flakybot on periodic (schedule) and continuous (push) events
-        if: ${{ (github.event_name == 'schedule' || github.event_name == 'push') && runner.os == 'Windows' && always() }}
+        if: ${{ (github.event_name == 'pull_request' || github.event_name == 'push') && runner.os == 'Windows' && always() }}
         run: |
           curl https://github.com/googleapis/repo-automation-bots/releases/download/flakybot-1.1.0/flakybot.exe -o flakybot.exe -s -L
           ./flakybot.exe --repo ${{github.repository}} --commit_hash ${{github.sha}} --build_url https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -122,8 +122,12 @@ jobs:
         # specifying bash shell ensures a failure in a piped process isn't lost by using `set -eo pipefail`
         shell: bash
         run: |
-          go install github.com/jstemmer/go-junit-report/v2@latest
           go test -race -v ./... | tee test_results.txt
+
+      - name: Convert test output to XML
+        if: ${{ (github.event_name == 'schedule' || github.event_name == 'push') && always() }}
+        run: |
+          go install github.com/jstemmer/go-junit-report/v2@latest
           go-junit-report -in test_results.txt -set-exit-code -out integration_sponge_log.xml
 
       - name: FlakyBot (Linux)

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -119,8 +119,8 @@ jobs:
           SQLSERVER_DB: '${{ steps.secrets.outputs.SQLSERVER_DB }}'
           TMPDIR: "/tmp"
           TMP: '${{ runner.temp }}'
+        shell: bash
         run: |
-          set -o pipefail # ensures a failure in a piped process isn't lost
           go install github.com/jstemmer/go-junit-report/v2@latest
           go test -race -v ./... | tee test_results.txt
           go-junit-report -in test_results.txt -set-exit-code -out integration_sponge_log.xml

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -120,6 +120,7 @@ jobs:
           TMPDIR: "/tmp"
           TMP: '${{ runner.temp }}'
         run: |
+          set -o pipefail # ensures a failure in a piped process isn't lost
           go install github.com/jstemmer/go-junit-report/v2@latest
           go test -race -v ./... | tee test_results.txt
           go-junit-report -in test_results.txt -set-exit-code -out integration_sponge_log.xml

--- a/.github/workflows/v1-periodic.yaml
+++ b/.github/workflows/v1-periodic.yaml
@@ -90,6 +90,7 @@ jobs:
           TMPDIR: "/tmp"
           TMP: '${{ runner.temp }}'
         run: |
+          set -o pipefail # ensures a failure in a piped process isn't lost
           go install github.com/jstemmer/go-junit-report/v2@latest
           go test -race -v ./... | tee test_results.txt
           go-junit-report -in test_results.txt -set-exit-code -out v1periodic_sponge_log.xml

--- a/.github/workflows/v1-periodic.yaml
+++ b/.github/workflows/v1-periodic.yaml
@@ -89,8 +89,9 @@ jobs:
           SQLSERVER_DB: '${{ steps.secrets.outputs.SQLSERVER_DB }}'
           TMPDIR: "/tmp"
           TMP: '${{ runner.temp }}'
+        # specifying bash shell ensures a failure in a piped process isn't lost by using `set -eo pipefail`
+        shell: bash
         run: |
-          set -o pipefail # ensures a failure in a piped process isn't lost
           go install github.com/jstemmer/go-junit-report/v2@latest
           go test -race -v ./... | tee test_results.txt
           go-junit-report -in test_results.txt -set-exit-code -out v1periodic_sponge_log.xml

--- a/.github/workflows/v1-periodic.yaml
+++ b/.github/workflows/v1-periodic.yaml
@@ -92,8 +92,12 @@ jobs:
         # specifying bash shell ensures a failure in a piped process isn't lost by using `set -eo pipefail`
         shell: bash
         run: |
-          go install github.com/jstemmer/go-junit-report/v2@latest
           go test -race -v ./... | tee test_results.txt
+
+      - name: Convert test output to XML
+        if: ${{ (github.event_name == 'schedule' || github.event_name == 'push') && always() }}
+        run: |
+          go install github.com/jstemmer/go-junit-report/v2@latest
           go-junit-report -in test_results.txt -set-exit-code -out v1periodic_sponge_log.xml
 
       - name: FlakyBot (Linux)


### PR DESCRIPTION
By explicitly configuring `shell: bash` in test step it enables `set -eo pipefail` ([documentation](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference)) which means errors in left side of pipe will no longer be suppressed by the success of the right side of the pipe.
```yaml
go test -race -v ./... | tee test_results.txt
```

Additionally, with new `pipefail` being set, if line that runs the test `go test -race -v ./... | tee test_results.txt` fails (i.e. a test fails) than this causes an exit code and for the line below it `go-junit-report ...` not to be run which in turn disables flakybot from working as it requires XML sponge log.

By moving the convert XML functionality to its own step in the workflow we can make sure it always runs no matter what happens with the tests.