### PR TITLE
chore: adjust release-please configuration to properly handle v1

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -16,9 +16,7 @@ handleGHRelease: true
 packageName: cloud-sql-proxy
 releaseType: simple
 versionFile: 'cmd/version.txt'
-changelogPath: 'CHANGELOG.md'
 branches:
 - branch: v1
   versionFile: 'cmd/cloud_sql_proxy/version.txt'
   releaseType: simple
-  changelogPath: 'CHANGELOG.md'

--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -16,6 +16,9 @@ handleGHRelease: true
 packageName: cloud-sql-proxy
 releaseType: simple
 versionFile: 'cmd/version.txt'
+changelogPath: 'CHANGELOG.md'
 branches:
 - branch: v1
   versionFile: 'cmd/cloud_sql_proxy/version.txt'
+  releaseType: simple
+  changelogPath: 'CHANGELOG.md'


### PR DESCRIPTION
Apply explicit configuration to the v1 branch so that it uses 'simple' strategy and 'CHANGELOG.md' for changes.