### PR TITLE
chore: fix piped test errors being suppressed

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -119,9 +119,15 @@ jobs:
           SQLSERVER_DB: '${{ steps.secrets.outputs.SQLSERVER_DB }}'
           TMPDIR: "/tmp"
           TMP: '${{ runner.temp }}'
+        # specifying bash shell ensures a failure in a piped process isn't lost by using `set -eo pipefail`
+        shell: bash
+        run: |
+          go test -race -v ./... | tee test_results.txt
+
+      - name: Convert test output to XML
+        if: ${{ (github.event_name == 'schedule' || github.event_name == 'push') && always() }}
         run: |
           go install github.com/jstemmer/go-junit-report/v2@latest
-          go test -race -v ./... | tee test_results.txt
           go-junit-report -in test_results.txt -set-exit-code -out integration_sponge_log.xml
 
       - name: FlakyBot (Linux)

--- a/.github/workflows/v1-periodic.yaml
+++ b/.github/workflows/v1-periodic.yaml
@@ -89,9 +89,15 @@ jobs:
           SQLSERVER_DB: '${{ steps.secrets.outputs.SQLSERVER_DB }}'
           TMPDIR: "/tmp"
           TMP: '${{ runner.temp }}'
+        # specifying bash shell ensures a failure in a piped process isn't lost by using `set -eo pipefail`
+        shell: bash
+        run: |
+          go test -race -v ./... | tee test_results.txt
+
+      - name: Convert test output to XML
+        if: ${{ github.event_name == 'schedule' && always() }}
         run: |
           go install github.com/jstemmer/go-junit-report/v2@latest
-          go test -race -v ./... | tee test_results.txt
           go-junit-report -in test_results.txt -set-exit-code -out v1periodic_sponge_log.xml
 
       - name: FlakyBot (Linux)


### PR DESCRIPTION
By explicitly configuring `shell: bash` in test step it enables `set -eo pipefail` ([documentation](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference)) which means errors in left side of pipe will no longer be suppressed by the success of the right side of the pipe.
```yaml
go test -race -v ./... | tee test_results.txt
```

Additionally, with new `pipefail` being set, if line that runs the test `go test -race -v ./... | tee test_results.txt` fails (i.e. a test fails) than this causes an exit code and for the line below it `go-junit-report ...` not to be run which in turn disables flakybot from working as it requires XML sponge log.

By moving the convert XML functionality to its own step in the workflow we can make sure it always runs no matter what happens with the tests.