### PR TITLE
chore: limit max concurrent PRs

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,15 +4,9 @@
     ":semanticCommitTypeAll(chore)"
   ],
   "ignorePresets": [
-      ":semanticPrefixFixDepsChoreOthers"
+    ":semanticPrefixFixDepsChoreOthers"
   ],
-  "packageRules": [
-    {
-      "excludedPackageNames": ["golang.org/x/net"],
-      "matchBaseBranches": ["v1"]
-    }
-  ],
-  "prConcurrentLimit": 0,
+  "prConcurrentLimit": 3,
   "rebaseStalePrs": true,
   "dependencyDashboard": true,
   "semanticCommits": true,


### PR DESCRIPTION
Also, remove unused v1 rules, since renovate doesn't run against multiple branches.