### PR TITLE
chore: bump Cloud Build timeout

### DIFF
--- a/.build/gcs_upload.yaml
+++ b/.build/gcs_upload.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-timeout: 900s
+timeout: 1800s
 options:
   env:
     - "GOPATH=/workspace/GOPATH"


### PR DESCRIPTION
Currently, the job takes ~18min