### PR TITLE
fix: return correct exit code on SIGTERM

### DIFF
--- a/cmd/errors.go
+++ b/cmd/errors.go
@@ -26,7 +26,7 @@ var (
 
 	errSigTerm = &exitError{
 		Err:  errors.New("SIGTERM signal received"),
-		Code: 137,
+		Code: 143,
 	}
 )
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -617,11 +617,6 @@ func runSignalWrapper(cmd *Command) error {
 	case p = <-startCh:
 		cmd.logger.Infof("The proxy has started successfully and is ready for new connections!")
 	}
-	defer func() {
-		if cErr := p.Close(); cErr != nil {
-			cmd.logger.Errorf("error during shutdown: %v", cErr)
-		}
-	}()
 
 	notify := func() {}
 	if cmd.healthCheck {
@@ -671,6 +666,15 @@ func runSignalWrapper(cmd *Command) error {
 		cmd.logger.Errorf("SIGTERM signal received. Shutting down...")
 	default:
 		cmd.logger.Errorf("The proxy has encountered a terminal error: %v", err)
+	}
+	cErr := p.Close()
+	if cErr != nil {
+		cmd.logger.Errorf("error during shutdown: %v", cErr)
+	}
+	// If Close succeeded and WaitOnClose is enabled, return no error to get a 0
+	// exit status.
+	if cErr == nil && cmd.conf.WaitOnClose != 0 {
+		return nil
 	}
 	return err
 }


### PR DESCRIPTION
SIGTERM (15) is 128+15=143 (not 137).

See https://tldp.org/LDP/abs/html/exitcodes.html and https://komodor.com/learn/exit-codes-in-containers-and-kubernetes-the-complete-guide/ for details.

Fixes #1529.