### PR TITLE
chore: disable arm64 build for bullseye

### DIFF
--- a/.build/bullseye.yaml
+++ b/.build/bullseye.yaml
@@ -56,4 +56,4 @@ options:
   env:
     - DOCKER_CLI_EXPERIMENTAL=enabled
 substitutions:
-  _DOCKER_BUILDX_PLATFORMS: 'linux/amd64,linux/arm64'
+  _DOCKER_BUILDX_PLATFORMS: 'linux/amd64'


### PR DESCRIPTION
Restoring this is tracked in #1508.