### PR TITLE
chore: default expose port values in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,4 +30,5 @@ FROM gcr.io/distroless/static:nonroot
 COPY --from=build --chown=nonroot /go/src/cloud-sql-proxy/cloud-sql-proxy /cloud-sql-proxy
 # set the uid as an integer for compatibility with runAsNonRoot in Kubernetes
 USER 65532
+EXPOSE 5432 3306 1433
 ENTRYPOINT ["/cloud-sql-proxy"]

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -37,5 +37,7 @@ RUN addgroup -g 65532 -S nonroot && adduser -u 65532 -S nonroot -G nonroot
 # Set the uid as an integer for compatibility with runAsNonRoot in Kubernetes
 USER 65532
 
+EXPOSE 5432 3306 1433
+
 COPY --from=build --chown=nonroot /go/src/cloud-sql-proxy/cloud-sql-proxy /cloud-sql-proxy
 ENTRYPOINT ["/cloud-sql-proxy"]

--- a/Dockerfile.bullseye
+++ b/Dockerfile.bullseye
@@ -35,5 +35,7 @@ RUN groupadd -g 65532 -r nonroot && useradd -u 65532 -g 65532 -r nonroot
 # Set the uid as an integer for compatibility with runAsNonRoot in Kubernetes
 USER 65532
 
+EXPOSE 5432 3306 1433
+
 COPY --from=build --chown=nonroot /go/src/cloud-sql-proxy/cloud-sql-proxy /cloud-sql-proxy
 ENTRYPOINT ["/cloud-sql-proxy"]

--- a/Dockerfile.buster
+++ b/Dockerfile.buster
@@ -35,5 +35,7 @@ RUN groupadd -g 65532 -r nonroot && useradd -u 65532 -g 65532 -r nonroot
 # Set the uid as an integer for compatibility with runAsNonRoot in Kubernetes
 USER 65532
 
+EXPOSE 5432 3306 1433
+
 COPY --from=build --chown=nonroot /go/src/cloud-sql-proxy/cloud-sql-proxy /cloud-sql-proxy
 ENTRYPOINT ["/cloud-sql-proxy"]


### PR DESCRIPTION
## Change Description
When running a cloud sql proxy as a "service container" in Gitlab CI or Github Actions they do health check on the `EXPOSE` port in the container. So when running the upstream container as a service it will fail to start due to missing EXPOSE keyword in Dockerfile.  

## Checklist

## Relevant issues:

- Fixes #1544