### PR TITLE
docs: fix windows release URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,9 @@ chmod +x cloud-sql-proxy
 
 ```sh
 # see Releases for other versions
-wget https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy/v2.0.0-preview.3/cloud-sql-proxy-x64.exe -O cloud-sql-proxy.exe
+URL="https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy/v2.0.0-preview.3"
+
+wget "$URL/cloud-sql-proxy.x64.exe" -O cloud-sql-proxy.exe
 ```
 
 </details>
@@ -148,7 +150,9 @@ wget https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy/v2.0.0-
 
 ```sh
 # see Releases for other versions
-wget https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy/v2.0.0-preview.3/cloud-sql-proxy-x86.exe -O cloud-sql-proxy.exe
+URL="https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy/v2.0.0-preview.3"
+
+wget "$URL/cloud-sql-proxy.x86.exe" -O cloud-sql-proxy.exe
 ```
 
 </details>


### PR DESCRIPTION
## Change Description

Update the broken links for windows release URLs in README file 
incorrect: cloud-sql-proxy-x64.exe
correct: cloud-sql-proxy.x64.exe


## Checklist

- [x] Make sure to open an issue as a 
  [bug/issue](https://github.com/GoogleCloudPlatform/cloudsql-proxy/issues/new/choose) 
  before writing your code!  That way we can discuss the change, evaluate 
  designs, and agree on the general idea.
- [x] Ensure the tests and linter pass
- [x] Appropriate documentation is updated (if necessary)

## Relevant issues:

- Fixes https://github.com/GoogleCloudPlatform/cloud-sql-proxy/issues/1558