### PR TITLE
docs: Add automatic IAM Authentication Example

### DIFF
--- a/examples/k8s-sidecar/proxy_with_iam_workload_identity.yaml
+++ b/examples/k8s-sidecar/proxy_with_iam_workload_identity.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/k8s-sidecar/proxy_with_iam_workload_identity.yaml
+++ b/examples/k8s-sidecar/proxy_with_iam_workload_identity.yaml
@@ -52,7 +52,7 @@ spec:
           # - "--private-ip"
 
           # Enable Automatic IAM Authentication
-          - "--enable-iam-login" # NOT SURE IF THIS IS THE CORRECT ARGUMENT!
+          - "--enable-iam-login" # I AM NOT SURE IF THIS IS THE CORRECT ARGUMENT!
 
           # Enable structured logging with LogEntry format:
           - "--structured-logs"

--- a/examples/k8s-sidecar/proxy_with_iam_workload_identity.yaml
+++ b/examples/k8s-sidecar/proxy_with_iam_workload_identity.yaml
@@ -45,7 +45,7 @@ spec:
       - name: cloud-sql-proxy
         # It is recommended to use the latest version of the Cloud SQL proxy
         # Make sure to update on a regular schedule!
-        image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.0.0.preview.0  # make sure the use the latest version
+        image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.0.0-preview.4  # make sure the use the latest version
         args:
           # If connecting from a VPC-native GKE cluster, you can use the
           # following flag to have the proxy connect over private IP

--- a/examples/k8s-sidecar/proxy_with_iam_workload_identity.yaml
+++ b/examples/k8s-sidecar/proxy_with_iam_workload_identity.yaml
@@ -1,0 +1,83 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START cloud_sql_proxy_k8s_sa]
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: <YOUR-DEPLOYMENT-NAME>
+spec:
+  selector:
+    matchLabels:
+      app: <YOUR-APPLICATION-NAME>
+  template:
+    metadata:
+      labels:
+        app: <YOUR-APPLICATION-NAME>
+    spec:
+      serviceAccountName: <YOUR-KSA-NAME>
+      # [END cloud_sql_proxy_k8s_sa]
+      # [START cloud_sql_proxy_k8s_secrets]
+      containers:
+      - name: <YOUR-APPLICATION-NAME>
+        # ... other container configuration
+        env:
+        - name: DB_USER
+          # For a service account, this is the service account's email
+          # without the .gserviceaccount.com domain suffix.
+          # Example: gke-service-account@my-project.iam
+          value: <YOUR-CLOUD-SQL-IAM-DB-USER>
+        - name: DB_NAME
+          value: <YOUR-DB-NAME>
+      # [END cloud_sql_proxy_k8s_secrets]
+      # [START cloud_sql_proxy_k8s_container]
+      - name: cloud-sql-proxy
+        # It is recommended to use the latest version of the Cloud SQL proxy
+        # Make sure to update on a regular schedule!
+        image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.0.0.preview.0  # make sure the use the latest version
+        args:
+          # If connecting from a VPC-native GKE cluster, you can use the
+          # following flag to have the proxy connect over private IP
+          # - "--private-ip"
+
+          # Enable Automatic IAM Authentication
+          - "--enable-iam-login" # NOT SURE IF THIS IS THE CORRECT ARGUMENT!
+
+          # Enable structured logging with LogEntry format:
+          - "--structured-logs"
+
+          # Replace DB_PORT with the port the proxy should listen on
+          - "--port=<DB_PORT>"
+          - "<INSTANCE_CONNECTION_NAME>"
+        
+        securityContext:
+          # The default Cloud SQL proxy image runs as the
+          # "nonroot" user and group (uid: 65532) by default.
+          runAsNonRoot: true
+        # You should use resource requests/limits as a best practice to prevent
+        # pods from consuming too many resources and affecting the execution of
+        # other pods. You should adjust the following values based on what your
+        # application needs. For details, see
+        # https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+        resources:
+          requests:
+            # The proxy's memory use scales linearly with the number of active
+            # connections. Fewer open connections will use less memory. Adjust
+            # this value based on your application's requirements.
+            memory: "2Gi"
+            # The proxy's CPU use scales linearly with the amount of IO between
+            # the database and the application. Adjust this value based on your
+            # application's requirements.
+            cpu:    "1"
+      # [END cloud_sql_proxy_k8s_container]


### PR DESCRIPTION
## Change Description

I would like to add Automatic IAM Authentication to the examples on https://cloud.google.com/sql/docs/mysql/connect-kubernetes-engine

One step in doing that is adding an example `.yaml` file for the sidecar deployment.