### PR TITLE
feat: Add unix-socket-path to instance command arguments.

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -173,11 +173,11 @@ Instance Level Configuration
     	    'my-project:us-central1:my-other-server?address=0.0.0.0&port=7000'
 
     When necessary, you may specify the full path to a Unix socket. Set the
-    unix-socket-path query parameter to the absolute path of the unix socket for
+    unix-socket-path query parameter to the absolute path of the Unix socket for
     the database instance. The parent directory of the unix-socket-path must 
     exist when the proxy starts or else socket creation will fail. For Postgres
     instances, the proxy will ensure that the last path element is 
-		'.s.PGSQL.5432' appending it if necessary. For example,
+    '.s.PGSQL.5432' appending it if necessary. For example,
 
         ./cloud-sql-proxy \
           'my-project:us-central1:my-db-server?unix-socket-path=/path/to/socket'

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -172,16 +172,15 @@ Instance Level Configuration
     	    my-project:us-central1:my-db-server \
     	    'my-project:us-central1:my-other-server?address=0.0.0.0&port=7000'
 
-Instance Level Configuration Parameters:
+    When necessary, you may specify the full path to a Unix socket. Set the
+    unix-socket-path query parameter to the absolute path of the unix socket for
+    the database instance. The parent directory of the unix-socket-path must 
+    exist when the proxy starts or else socket creation will fail. For Postgres
+    instances, the proxy will ensure that the last path element is 
+		'.s.PGSQL.5432' appending it if necessary. For example,
 
-    There is a parameter that may only be set at the instance, and does not have
-    a corresponding global parameter.
-
-    - unix-socket-path - UnixSocketPath is the path where a Unix socket will be
-    created for a Cloud SQL instance. If set on a Postgres instance, the proxy
-    will ensure that the last path element is '.s.PGSQL.5432', appending this
-		path element if necessary. unix-socket-path takes precedence over
-    the global parameter --unix-socket when both are set.
+        ./cloud-sql-proxy \
+          'my-project:us-central1:my-db-server?unix-socket-path=/path/to/socket'
 
 Health checks
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -178,7 +178,7 @@ Instance Level Configuration Parameters:
     a corresponding global parameter.
 
     - unix-socket-path - UnixSocketPath is the path where a Unix socket will be
-    created for a Cloud SQL instance. If this is a Postgres database, the proxy
+    created for a Cloud SQL instance. If set on a Postgres instance, the proxy
     will ensure that the last path element is '.s.PGSQL.5432', appending this
 		path element if necessary. unix-socket-path takes precedence over
     the global parameter --unix-socket when both are set.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -543,12 +543,22 @@ func parseConfig(cmd *Command, conf *proxy.Config, args []string) error {
 			a, aok := q["address"]
 			p, pok := q["port"]
 			u, uok := q["unix-socket"]
+			up, upok := q["unix-socket-path"]
 
 			if aok && uok {
 				return newBadCommandError("cannot specify both address and unix-socket query params")
 			}
 			if pok && uok {
 				return newBadCommandError("cannot specify both port and unix-socket query params")
+			}
+			if aok && upok {
+				return newBadCommandError("cannot specify both address and unix-socket-path query params")
+			}
+			if pok && upok {
+				return newBadCommandError("cannot specify both port and unix-socket-path query params")
+			}
+			if uok && upok {
+				return newBadCommandError("cannot specify both unix-socket-path and unix-socket query params")
 			}
 
 			if aok {
@@ -583,6 +593,13 @@ func parseConfig(cmd *Command, conf *proxy.Config, args []string) error {
 					return newBadCommandError(fmt.Sprintf("unix query param should be only one value: %q", a))
 				}
 				ic.UnixSocket = u[0]
+			}
+
+			if upok {
+				if len(up) != 1 {
+					return newBadCommandError(fmt.Sprintf("unix-socket-path query param should be only one value: %q", a))
+				}
+				ic.UnixSocketPath = up[0]
 			}
 
 			ic.IAMAuthN, err = parseBoolOpt(q, "auto-iam-authn")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -172,6 +172,17 @@ Instance Level Configuration
     	    my-project:us-central1:my-db-server \
     	    'my-project:us-central1:my-other-server?address=0.0.0.0&port=7000'
 
+Instance Level Configuration Parameters:
+
+    There is a parameter that may only be set at the instance, and does not have
+    a corresponding global parameter.
+
+    - unix-socket-path - UnixSocketPath is the path where a Unix socket will be
+    created for a Cloud SQL instance. If this is a Postgres database, the proxy
+    will ensure that the last path element is '.s.PGSQL.5432', appending this
+		path element if necessary. unix-socket-path takes precedence over
+    the global parameter --unix-socket when both are set.
+
 Health checks
 
     When enabling the --health-check flag, the proxy will start an HTTP server

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -288,10 +288,10 @@ func TestNewCommandArguments(t *testing.T) {
 		},
 		{
 			desc: "using the unix socket path query param",
-			args: []string{"proj:region:inst?unix-socket-path=/path/to/dir/"},
+			args: []string{"proj:region:inst?unix-socket-path=/path/to/file"},
 			want: withDefaults(&proxy.Config{
 				Instances: []proxy.InstanceConnConfig{{
-					UnixSocketPath: "/path/to/dir/",
+					UnixSocketPath: "/path/to/file",
 				}},
 			}),
 		},
@@ -969,12 +969,24 @@ func TestNewCommandWithErrors(t *testing.T) {
 			args: []string{"-u", "/path/to/dir/", "-p", "5432", "proj:region:inst"},
 		},
 		{
+			desc: "using the unix socket and unix-socket-path",
+			args: []string{"proj:region:inst?unix-socket=/path&unix-socket-path=/another/path"},
+		},
+		{
 			desc: "using the unix socket and addr query params",
 			args: []string{"proj:region:inst?unix-socket=/path&address=127.0.0.1"},
 		},
 		{
+			desc: "using the unix socket path and addr query params",
+			args: []string{"proj:region:inst?unix-socket-path=/path&address=127.0.0.1"},
+		},
+		{
 			desc: "using the unix socket and port query params",
 			args: []string{"proj:region:inst?unix-socket=/path&port=5000"},
+		},
+		{
+			desc: "using the unix socket path and port query params",
+			args: []string{"proj:region:inst?unix-socket-path=/path&port=5000"},
 		},
 		{
 			desc: "when the iam authn login query param contains multiple values",

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -287,6 +287,15 @@ func TestNewCommandArguments(t *testing.T) {
 			}),
 		},
 		{
+			desc: "using the unix socket path query param",
+			args: []string{"proj:region:inst?unix-socket-path=/path/to/dir/"},
+			want: withDefaults(&proxy.Config{
+				Instances: []proxy.InstanceConnConfig{{
+					UnixSocketPath: "/path/to/dir/",
+				}},
+			}),
+		},
+		{
 			desc: "using the iam authn login flag",
 			args: []string{"--auto-iam-authn", "proj:region:inst"},
 			want: withDefaults(&proxy.Config{

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -742,7 +742,7 @@ func newSocketMount(ctx context.Context, conf *Config, pc *portConfig, inst Inst
 
 		address = net.JoinHostPort(a, fmt.Sprint(np))
 
-	case inst.UnixSocketPath != "" && strings.HasPrefix(version, "POSTGRES") :
+	case inst.UnixSocketPath != "" && strings.HasPrefix(version, "POSTGRES"):
 		// When UnixSocketPath is set for a Postgres database...
 		network = "unix"
 
@@ -771,7 +771,7 @@ func newSocketMount(ctx context.Context, conf *Config, pc *portConfig, inst Inst
 		}
 		address = UnixAddress(address, ".s.PGSQL.5432")
 
-	case inst.UnixSocketPath != "" :
+	case inst.UnixSocketPath != "":
 		network = "unix"
 		address = inst.UnixSocketPath
 		dir := path.Dir(address)

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -779,7 +779,7 @@ func newUnixSocketMount(inst InstanceConnConfig, unixSocketDir, version string) 
 	)
 
 	if inst.UnixSocketPath != "" {
-		// When UnixSocketPath is set...
+		// When UnixSocketPath is set
 		address = inst.UnixSocketPath
 
 		// If UnixSocketPath ends .s.PGSQL.5432, remove it for consistency
@@ -789,7 +789,7 @@ func newUnixSocketMount(inst InstanceConnConfig, unixSocketDir, version string) 
 
 		dir = path.Dir(address)
 	} else {
-		// when UnixSocket is set
+		// When UnixSocket is set
 		dir = unixSocketDir
 		if dir == "" {
 			dir = inst.UnixSocket

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -87,7 +87,7 @@ type InstanceConnConfig struct {
 	// connected to the Cloud SQL instance. The full path to the socket will be
 	// UnixSocket + os.PathSeparator + Name. If set, takes precedence over Addr and Port.
 	UnixSocket string
-	// UnixSocketPath is the directory where a Unix socket will be created,
+	// UnixSocketPath is the path where a Unix socket will be created,
 	// connected to the Cloud SQL instance. The full path to the socket will be
 	// UnixSocketPath. If this is a Postgres database, the proxy will ensure that
 	// the last path element is `.s.PGSQL.5432`, appending this path element if

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -273,6 +273,18 @@ func TestClientInitialization(t *testing.T) {
 			},
 		},
 		{
+			desc: "with a Unix socket path overriding Unix socket",
+			in: &proxy.Config{
+				UnixSocket: testDir,
+				Instances: []proxy.InstanceConnConfig{
+					{Name: mysql, UnixSocketPath: testUnixSocketPath},
+				},
+			},
+			wantUnixAddrs: []string{
+				filepath.Join(testUnixSocketPath),
+			},
+		},
+		{
 			desc: "with a Unix socket path per pg instance",
 			in: &proxy.Config{
 				Instances: []proxy.InstanceConnConfig{

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"net"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -114,6 +115,9 @@ func createTempDir(t *testing.T) (string, func()) {
 func TestClientInitialization(t *testing.T) {
 	ctx := context.Background()
 	testDir, cleanup := createTempDir(t)
+	testUnixSocketPath := path.Join(testDir, "db")
+	testUnixSocketPathPg := path.Join(testDir, "db", ".s.PGSQL.5432")
+
 	defer cleanup()
 
 	tcs := []struct {
@@ -255,6 +259,39 @@ func TestClientInitialization(t *testing.T) {
 			},
 			wantUnixAddrs: []string{
 				filepath.Join(testDir, pg, ".s.PGSQL.5432"),
+			},
+		},
+		{
+			desc: "with a Unix socket path per instance",
+			in: &proxy.Config{
+				Instances: []proxy.InstanceConnConfig{
+					{Name: mysql, UnixSocketPath: testUnixSocketPath},
+				},
+			},
+			wantUnixAddrs: []string{
+				filepath.Join(testUnixSocketPath),
+			},
+		},
+		{
+			desc: "with a Unix socket path per pg instance",
+			in: &proxy.Config{
+				Instances: []proxy.InstanceConnConfig{
+					{Name: pg, UnixSocketPath: testUnixSocketPath},
+				},
+			},
+			wantUnixAddrs: []string{
+				filepath.Join(testUnixSocketPathPg),
+			},
+		},
+		{
+			desc: "with a Unix socket path per pg instance and explicit pg path suffix",
+			in: &proxy.Config{
+				Instances: []proxy.InstanceConnConfig{
+					{Name: pg, UnixSocketPath: testUnixSocketPathPg},
+				},
+			},
+			wantUnixAddrs: []string{
+				filepath.Join(testUnixSocketPathPg),
 			},
 		},
 	}


### PR DESCRIPTION
## Change Description

This adds a new parameter `unix-socket-path` to instances to specify the precise unix socket path. 

For example, this command line: 

```
$ cloud-sql-proxy my-project:region:mydb?unix-socket-path=/var/cloudsql/mydb 
```

Will open a unix socket to the database at the path `/var/cloudsql/mydb`.

This is different than the existing parameter `unix-socket` which automatically appends the instance name to the path. 

## Checklist

- [x] Open issue: #1573.
- [x] Ensure the tests and linter pass
- [x] Appropriate documentation is updated (if necessary)

## Relevant issues:

- Fixes #1573