### PR TITLE
docs: fix port number in k8s-health-check

### DIFF
--- a/examples/k8s-health-check/README.md
+++ b/examples/k8s-health-check/README.md
@@ -42,7 +42,7 @@ To configure the address, use `--http-address`. To configure the port, use
 livenessProbe:
   httpGet:
     path: /liveness
-    port: 8090
+    port: 9090
   # Number of seconds after the container has started before the first probe is scheduled. Defaults to 0.
   # Not necessary when the startup probe is in use.
   initialDelaySeconds: 0
@@ -56,7 +56,7 @@ livenessProbe:
 readinessProbe:
   httpGet:
     path: /readiness
-    port: 8090
+    port: 9090
   initialDelaySeconds: 0
   periodSeconds: 10
   timeoutSeconds: 5
@@ -67,7 +67,7 @@ readinessProbe:
 startupProbe:
   httpGet:
     path: /startup
-    port: 8090
+    port: 9090
   periodSeconds: 1
   timeoutSeconds: 5
   failureThreshold: 20

--- a/examples/k8s-health-check/proxy_with_http_health_check.yaml
+++ b/examples/k8s-health-check/proxy_with_http_health_check.yaml
@@ -102,7 +102,7 @@ spec:
         livenessProbe:
           httpGet:
             path: /liveness
-            port: 8090
+            port: 9090
           # Number of seconds after the container has started before the first probe is scheduled. Defaults to 0.
           # Not necessary when the startup probe is in use.
           initialDelaySeconds: 0
@@ -122,7 +122,7 @@ spec:
         readinessProbe:
           httpGet:
             path: /readiness
-            port: 8090
+            port: 9090
           initialDelaySeconds: 0
           periodSeconds: 10
           timeoutSeconds: 5
@@ -133,7 +133,7 @@ spec:
         startupProbe:
           httpGet:
             path: /startup
-            port: 8090
+            port: 9090
           periodSeconds: 1
           timeoutSeconds: 5
           failureThreshold: 20


### PR DESCRIPTION
## Change Description

I changed the value of port in k8s-health-check, because the default value is `9090`.

## Checklist

- [ ] Make sure to open an issue as a 
  [bug/issue](https://github.com/GoogleCloudPlatform/cloudsql-proxy/issues/new/choose) 
  before writing your code!  That way we can discuss the change, evaluate 
  designs, and agree on the general idea.
- [ ] Ensure the tests and linter pass
- [ ] Appropriate documentation is updated (if necessary)

## Relevant issues:

- Fixes #1635 