### PR TITLE
fix: ensure separate token source with auto-iam-authn

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -520,8 +520,6 @@ func parseConfig(cmd *Command, conf *proxy.Config, args []string) error {
 		return newBadCommandError("cannot specify --login-token without --token and --auto-iam-authn")
 	}
 
-	// if login token is set, but token is not error
-
 	if userHasSet("http-port") && !userHasSet("prometheus") && !userHasSet("health-check") {
 		cmd.logger.Infof("Ignoring --http-port because --prometheus or --health-check was not set")
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -175,9 +175,9 @@ Instance Level Configuration
 
     When necessary, you may specify the full path to a Unix socket. Set the
     unix-socket-path query parameter to the absolute path of the Unix socket for
-    the database instance. The parent directory of the unix-socket-path must 
+    the database instance. The parent directory of the unix-socket-path must
     exist when the proxy starts or else socket creation will fail. For Postgres
-    instances, the proxy will ensure that the last path element is 
+    instances, the proxy will ensure that the last path element is
     '.s.PGSQL.5432' appending it if necessary. For example,
 
         ./cloud-sql-proxy \
@@ -371,6 +371,8 @@ func NewCommand(opts ...Option) *Command {
 		"Space separated list of additional user agents, e.g. cloud-sql-proxy-operator/0.0.1")
 	pflags.StringVarP(&c.conf.Token, "token", "t", "",
 		"Use bearer token as a source of IAM credentials.")
+	pflags.StringVar(&c.conf.LoginToken, "login-token", "",
+		"Use bearer token as a database password (used with token and auto-iam-authn only)")
 	pflags.StringVarP(&c.conf.CredentialsFile, "credentials-file", "c", "",
 		"Use service account key file as a source of IAM credentials.")
 	pflags.StringVarP(&c.conf.CredentialsJSON, "json-credentials", "j", "",
@@ -508,6 +510,17 @@ func parseConfig(cmd *Command, conf *proxy.Config, args []string) error {
 	if conf.CredentialsJSON != "" && conf.GcloudAuth {
 		return newBadCommandError("cannot specify --json-credentials and --gcloud-auth flags at the same time")
 	}
+
+	// When using token with auto-iam-authn, login-token must also be set.
+	// All three are required together.
+	if conf.IAMAuthN && conf.Token != "" && conf.LoginToken == "" {
+		return newBadCommandError("cannot specify --auto-iam-authn and --token without --login-token")
+	}
+	if conf.LoginToken != "" && (conf.Token == "" || !conf.IAMAuthN) {
+		return newBadCommandError("cannot specify --login-token without --token and --auto-iam-authn")
+	}
+
+	// if login token is set, but token is not error
 
 	if userHasSet("http-port") && !userHasSet("prometheus") && !userHasSet("health-check") {
 		cmd.logger.Infof("Ignoring --http-port because --prometheus or --health-check was not set")

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -393,6 +393,18 @@ func TestNewCommandArguments(t *testing.T) {
 				QuitQuitQuit: true,
 			}),
 		},
+		{
+			desc: "using the login-token flag",
+			args: []string{
+				"--auto-iam-authn",
+				"--token", "MYTOK",
+				"--login-token", "MYLOGINTOKEN", "proj:region:inst"},
+			want: withDefaults(&proxy.Config{
+				IAMAuthN:   true,
+				Token:      "MYTOK",
+				LoginToken: "MYLOGINTOKEN",
+			}),
+		},
 	}
 
 	for _, tc := range tcs {
@@ -1019,6 +1031,20 @@ func TestNewCommandWithErrors(t *testing.T) {
 		{
 			desc: "using fuse-tmp-dir without fuse",
 			args: []string{"--fuse-tmp-dir", "/mydir"},
+		},
+		{
+			desc: "using --auto-iam-authn with just token flag",
+			args: []string{"--auto-iam-authn", "--token", "MYTOKEN", "p:r:i"},
+		},
+		{
+			desc: "using the --login-token without --token and --auto-iam-authn",
+			args: []string{"--login-token", "MYTOKEN", "p:r:i"},
+		},
+		{
+			desc: "using --token and --login-token without --auto-iam-authn",
+			args: []string{
+				"--token", "MYTOKEN",
+				"--login-token", "MYLOGINTOKEN", "p:r:i"},
 		},
 	}
 


### PR DESCRIPTION
When a caller passes the --token flag with --auto-iam-authn, the Proxy will now require a separate --login-token. This changes ensures a token with SQL Admin scope does not make its way into the ephemeral certificate. Instead, the value passed to --login-token will be used and should have only the sqlservice.login scope.