### PR TITLE
fix: require login_token with token and enable_iam_login

### DIFF
--- a/cmd/cloud_sql_proxy/cloud_sql_proxy.go
+++ b/cmd/cloud_sql_proxy/cloud_sql_proxy.go
@@ -102,7 +102,7 @@ dropped`,
 
 	// Settings for authentication.
 	token      = flag.String("token", "", "When set, the proxy uses this Bearer token for authorization.")
-	loginToken = flag.String("login_token", "", "Used in conjuction with --token and --enable_iam_login only")
+	loginToken = flag.String("login_token", "", "Used in conjunction with --token and --enable_iam_login only")
 	tokenFile  = flag.String("credential_file", "",
 		`If provided, this json file will be used to retrieve Service Account
 credentials.  You may set the GOOGLE_APPLICATION_CREDENTIALS environment
@@ -389,7 +389,7 @@ func authenticatedClient(ctx context.Context) (*http.Client, oauth2.TokenSource,
 		return authenticatedClientFromPath(ctx, *tokenFile)
 	}
 	// If login token has been set, but there is no token or
-	// enable_iam_login has not be set, error.
+	// enable_iam_login has not been set, error.
 	if *loginToken != "" && (*token == "" || !(*enableIAMLogin)) {
 		return nil, nil, errLoginToken
 	}

--- a/cmd/cloud_sql_proxy/cloud_sql_proxy_test.go
+++ b/cmd/cloud_sql_proxy/cloud_sql_proxy_test.go
@@ -18,6 +18,8 @@ import (
 	"os"
 	"strings"
 	"testing"
+
+	"golang.org/x/net/context"
 )
 
 func TestVersionStripsNewline(t *testing.T) {
@@ -29,5 +31,72 @@ func TestVersionStripsNewline(t *testing.T) {
 
 	if got := semanticVersion(); got != want {
 		t.Fatalf("want = %q, got = %q", want, got)
+	}
+}
+
+func TestAuthenticatedClient(t *testing.T) {
+	tcs := []struct {
+		desc    string
+		setup   func() func()
+		wantErr bool
+	}{
+		{
+			desc: "when just token is set",
+			setup: func() func() {
+				*token = "MYTOKEN"
+				return func() {
+					*token = ""
+				}
+			},
+			wantErr: false,
+		},
+		{
+			desc: "when just login_token is set",
+			setup: func() func() {
+				*loginToken = "MYTOKEN"
+				return func() {
+					*loginToken = ""
+				}
+			},
+			wantErr: true,
+		},
+		{
+			desc: "when token and enable_iam_login are set",
+			setup: func() func() {
+				*token = "MYTOKEN"
+				*enableIAMLogin = true
+				return func() {
+					*token = ""
+					*enableIAMLogin = false
+				}
+			},
+			wantErr: true,
+		},
+		{
+			desc: "when token, login_token, and enable_iam_login are set",
+			setup: func() func() {
+				*token = "MYTOKEN"
+				*loginToken = "MYLOGINTOKEN"
+				*enableIAMLogin = true
+				return func() {
+					*token = ""
+					*loginToken = ""
+					*enableIAMLogin = false
+				}
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.desc, func(t *testing.T) {
+			cleanup := tc.setup()
+			defer cleanup()
+			_, _, err := authenticatedClient(context.Background())
+			gotErr := err != nil
+			if tc.wantErr != gotErr {
+				t.Fatalf("err: want = %v, got = %v", tc.wantErr, gotErr)
+			}
+		})
 	}
 }


### PR DESCRIPTION
When token and enable_iam_login are provided,
the caller must also provide a login token to
ensure only a minimally scoped token in embedded
into the ephemeral certificate.