### PR TITLE
chore: update examples proxy version to v2.1.0

### DIFF
--- a/examples/k8s-health-check/proxy_with_http_health_check.yaml
+++ b/examples/k8s-health-check/proxy_with_http_health_check.yaml
@@ -49,7 +49,7 @@ spec:
       - name: cloud-sql-proxy
         # It is recommended to use the latest version of the Cloud SQL proxy
         # Make sure to update on a regular schedule!
-        image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.0.0  # make sure to use the latest version
+        image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.1.0
         args:
           # If connecting from a VPC-native GKE cluster, you can use the
           # following flag to have the proxy connect over private IP

--- a/examples/k8s-service/pgbouncer_deployment.yaml
+++ b/examples/k8s-service/pgbouncer_deployment.yaml
@@ -82,7 +82,9 @@ spec:
         - name: CLIENT_TLS_CERT_FILE
           value: "/etc/server/cert.pem"
       - name: cloud-sql-proxy
-        image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.0.0  # make sure to use the latest version
+        # It is recommended to use the latest version of the Cloud SQL proxy
+        # Make sure to update on a regular schedule!
+        image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.1.0
         args:
           - "--port=5431"
           - "<INSTANCE_CONNECTION_NAME>"

--- a/examples/k8s-sidecar/proxy_with_sa_key.yaml
+++ b/examples/k8s-sidecar/proxy_with_sa_key.yaml
@@ -47,7 +47,7 @@ spec:
       - name: cloud-sql-proxy
         # It is recommended to use the latest version of the Cloud SQL proxy
         # Make sure to update on a regular schedule!
-        image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.0.0  # make sure to use the latest version
+        image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.1.0
         args:
           # If connecting from a VPC-native GKE cluster, you can use the
           # following flag to have the proxy connect over private IP

--- a/examples/k8s-sidecar/proxy_with_workload_identity.yaml
+++ b/examples/k8s-sidecar/proxy_with_workload_identity.yaml
@@ -53,7 +53,7 @@ spec:
       - name: cloud-sql-proxy
         # It is recommended to use the latest version of the Cloud SQL proxy
         # Make sure to update on a regular schedule!
-        image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.0.0  # make sure to use the latest version
+        image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.1.0
         args:
           # If connecting from a VPC-native GKE cluster, you can use the
           # following flag to have the proxy connect over private IP


### PR DESCRIPTION
Updating examples to point at latest version of the v2 proxy