### PR TITLE
fix: build statically linked binaries

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Use the latest stable golang 1.x to compile to a binary
-FROM --platform=$BUILDPLATFORM golang:1 as build
+FROM --platform=$BUILDPLATFORM golang:1-alpine as build
 
 WORKDIR /go/src/cloud-sql-proxy
 COPY . .
@@ -22,7 +22,7 @@ ARG TARGETOS
 ARG TARGETARCH
 
 RUN go get ./...
-RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
     go build -ldflags "-X github.com/GoogleCloudPlatform/cloud-sql-proxy/v2/cmd.metadataString=container.alpine"
 
 # Final stage

--- a/Dockerfile.bullseye
+++ b/Dockerfile.bullseye
@@ -22,7 +22,7 @@ ARG TARGETOS
 ARG TARGETARCH
 
 RUN go get ./...
-RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
     go build -ldflags "-X github.com/GoogleCloudPlatform/cloud-sql-proxy/v2/cmd.metadataString=container.bullseye"
 
 # Final stage

--- a/Dockerfile.buster
+++ b/Dockerfile.buster
@@ -22,7 +22,7 @@ ARG TARGETOS
 ARG TARGETARCH
 
 RUN go get ./...
-RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
     go build -ldflags "-X github.com/GoogleCloudPlatform/cloud-sql-proxy/v2/cmd.metadataString=container.buster"
 
 # Final stage


### PR DESCRIPTION
Dockerfiles should set `CGO_ENABLED=0` to statically link binaries, without it binaries are dynamically linked. This causes specific issues for alpine build as we were using the basic `golang:1.X` docker image to build the binary which is a debian image. Updating the alpine build to use `golang:1.X-alpine` for its build step.

Fixes #1678 