### PR TITLE
docs: fix typo in k8s-health-check example

### DIFF
--- a/examples/k8s-health-check/README.md
+++ b/examples/k8s-health-check/README.md
@@ -87,7 +87,7 @@ args:
   - "--health-check"
 
   # Listen on all addresses so the kubelet can reach the endpoints
-  - "--http-address 0.0.0.0"
+  - "--http-address=0.0.0.0"
 
   # Set the port where the HTTP server listens
   # - "--http-port 9090"

--- a/examples/k8s-health-check/proxy_with_http_health_check.yaml
+++ b/examples/k8s-health-check/proxy_with_http_health_check.yaml
@@ -59,7 +59,7 @@ spec:
           - "--health-check"
 
           # Listen on all addresses so the kubelet can reach the endpoints
-          - "--http-address 0.0.0.0"
+          - "--http-address=0.0.0.0"
 
           # Set the port where the HTTP server listens
           # - "--http-port 9090"


### PR DESCRIPTION
Hi,
I'm not sure if it's a typo but the `=` is needed in my case and used on [the other key/value args](https://github.com/GoogleCloudPlatform/cloud-sql-proxy/blob/v2.1.1/examples/k8s-health-check/README.md?plain=1#L100). 