### PR TITLE
doc: Improve examples for k8s readiness probes.

### DIFF
--- a/examples/k8s-health-check/README.md
+++ b/examples/k8s-health-check/README.md
@@ -18,16 +18,35 @@ localhost with three endpoints:
 - `/startup`: Returns 200 status when the proxy has finished starting up.
 Otherwise returns 503 status.
 
-- `/readiness`: Returns 200 status when the proxy has started, has available
-connections if max connections have been set with the `--max-connections`
-flag, and when the proxy can connect to all registered instances. Otherwise,
-returns a 503 status. Optionally supports a min-ready query param (e.g.,
-`/readiness?min-ready=3`) where the proxy will return a 200 status if the
-proxy can connect successfully to at least min-ready number of instances. If
-min-ready exceeds the number of registered instances, returns a 400.
-
 - `/liveness`: Always returns 200 status. If this endpoint is not responding,
 the proxy is in a bad state and should be restarted.
+
+- `/readiness`: Returns 200 status when the proxy has started, has available
+  connections if max connections have been set with the `--max-connections`
+  flag, and when the proxy can connect to all registered instances. Otherwise,
+  returns a 503 status. Optionally supports a min-ready query param (e.g.,
+  `/readiness?min-ready=3`) where the proxy will return a 200 status if the
+  proxy can connect successfully to at least min-ready number of instances. If
+  min-ready exceeds the number of registered instances, returns a 400.
+
+For most common usage, we do not recommend adding a readiness probe to the 
+proxy sidecar container because it may cause unnecessary interruption to the
+application's availability.
+
+This readiness probe will fail when (1) the proxy used all its available
+concurrent connections to a database or (2) the network connection
+to the database is interrupted. These are transient states
+that usually resolve within a few seconds. If the application is resilliant to
+transient database connection failures, then it should recover without requiring
+k8s to restart the pod. 
+
+However, if the readiness check fails, k8s will kill the pod: both application
+container and the proxy container. If your application would otherwise be able
+to recover from a transient failure, this is an unnecessary interruption which
+degrades the availability of the application.
+
+We recommend adding a readiness check to the application container instead of
+the proxy container.
 
 To configure the address, use `--http-address`. To configure the port, use
 `--http-port`.
@@ -39,41 +58,41 @@ To configure the address, use `--http-address`. To configure the port, use
 # Recommended configurations for health check probes.
 # Probe parameters can be adjusted to best fit the requirements of your application.
 # For details, see https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
-livenessProbe:
-  httpGet:
-    path: /liveness
-    port: 9090
-  # Number of seconds after the container has started before the first probe is scheduled. Defaults to 0.
-  # Not necessary when the startup probe is in use.
-  initialDelaySeconds: 0
-  # Frequency of the probe. Defaults to 10.
-  periodSeconds: 10
-  # Number of seconds after which the probe times out. Defaults to 1.
-  timeoutSeconds: 5
-  # Number of times the probe is allowed to fail before the transition from healthy to failure state.
-  # Defaults to 3.
-  failureThreshold: 1
-readinessProbe:
-  httpGet:
-    path: /readiness
-    port: 9090
-  initialDelaySeconds: 0
-  periodSeconds: 10
-  timeoutSeconds: 5
-  # Number of times the probe must report success to transition from failure to healthy state.
-  # Defaults to 1 for readiness probe.
-  successThreshold: 1
-  failureThreshold: 1
 startupProbe:
-  httpGet:
-    path: /startup
-    port: 9090
-  periodSeconds: 1
-  timeoutSeconds: 5
-  failureThreshold: 20
+   # We recommend adding a startup probe to the proxy sidecar
+   # container. This will ensure that service traffic will be routed to
+   # the pod only after the proxy has successfully started.
+   httpGet:
+      path: /startup
+      port: 9090
+   periodSeconds: 1
+   timeoutSeconds: 5
+   failureThreshold: 20
+livenessProbe:
+   # We recommend adding a liveness probe to the proxy sidecar container.
+   httpGet:
+      path: /liveness
+      port: 9090
+   # Number of seconds after the container has started before the first probe is scheduled. Defaults to 0.
+   # Not necessary when the startup probe is in use.
+   initialDelaySeconds: 0
+   # Frequency of the probe.
+   periodSeconds: 60
+   # Number of seconds after which the probe times out.
+   timeoutSeconds: 30
+   # Number of times the probe is allowed to fail before the transition
+   # from healthy to failure state.
+   #
+   # If periodSeconds = 60, 5 tries will result in five minutes of
+   # checks. The proxy starts to refresh a certificate five minutes
+   # before its expiration. If those five minutes lapse without a
+   # successful refresh, the liveness probe will fail and the pod will be
+   # restarted.
+   failureThreshold: 5
+# We do not recommend adding a readiness probe under most circumstances
 ```
 
-2. Add `-use_http_health_check` and `-health-check-port` (optional) to your
+2. Add `--http-address` and `--http-port` (optional) to your
    proxy container configuration under `command: `.
     > [proxy_with_http_health_check.yaml](proxy_with_http_health_check.yaml#L53-L76)
 

--- a/examples/k8s-health-check/README.md
+++ b/examples/k8s-health-check/README.md
@@ -36,7 +36,7 @@ application's availability.
 This readiness probe will fail when (1) the proxy used all its available
 concurrent connections to a database or (2) the network connection
 to the database is interrupted. These are transient states
-that usually resolve within a few seconds. If the application is resilliant to
+that usually resolve within a few seconds. If the application is resilient to
 transient database connection failures, then it should recover without requiring
 k8s to restart the pod. 
 

--- a/examples/k8s-health-check/README.md
+++ b/examples/k8s-health-check/README.md
@@ -135,9 +135,9 @@ transient failures.
 
 ### Readiness Health Check Examples
 
-The DBA team performs database fail-overs drills without notice, and a
-batch job needs to restart if it cannot connect the database for 3 minutes. 
-Set the readiness check so that the pod will be restarted after 3 minutes
+The DBA team performs database fail-overs drills without notice. A
+batch job should fail if it cannot connect the database for 3 minutes. 
+Set the readiness check so that the pod will be terminated after 3 minutes
 of consecutive readiness check failures. (6 failed readiness checks taken every 30
 seconds, 6 x 30sec = 3 minutes.)
 
@@ -147,7 +147,7 @@ readinessProbe:
     path: /readiness
     port: 9090
   initialDelaySeconds: 30
-  # 300 sec period x 6 failures = 60 seconds
+  # 30 sec period x 6 failures = 3 min until the pod is terminated
   periodSeconds: 30
   failureThreshold: 6
   timeoutSeconds: 10
@@ -178,8 +178,9 @@ for more than 1 minute.
             path: /readiness
             port: 9090
         initialDelaySeconds: 10
+        # 5 sec period x 12 failures = 60 sec until the pod is terminated
         periodSeconds: 5
-        failureThreshold: 12 # restart the pod after 12 failed attempts every 5 sec = 60 sec
+        failureThreshold: 12 
         timeoutSeconds: 5
         successThreshold: 1
 ```

--- a/examples/k8s-health-check/proxy_with_http_health_check.yaml
+++ b/examples/k8s-health-check/proxy_with_http_health_check.yaml
@@ -142,18 +142,9 @@ spec:
           # The /readiness probe returns OK when the proxy can establish
           # a new connections to its databases.
           #
-          # We do not recommend adding a readiness probe to the proxy sidecar
-          # container because it may cause unnecessary interruption to the
-          # application.
-          #
-          # This probe will fail when (1) the proxy used all its available
-          # concurrent connections to a database or (2) the network connection
-          # to the database is interrupted. These are transient states
-          # that resolve within a few seconds. However, if the readiness check
-          # fails too many times, k8s will kill the pod application container
-          # and the proxy container to be shut down. This is an undesirable
-          # result if the application is using a database connection
-          # pool with built-in resilience to transient failed connections.
+          # Please use the readiness probe to the proxy sidecar with caution.
+          # An improperly configured readiness probe can cause unnecessary
+          # interruption to the application. See README.md for more detail.
           httpGet:
             path: /readiness
             port: 9090

--- a/examples/k8s-health-check/proxy_with_http_health_check.yaml
+++ b/examples/k8s-health-check/proxy_with_http_health_check.yaml
@@ -99,7 +99,26 @@ spec:
         # Recommended configurations for health check probes.
         # Probe parameters can be adjusted to best fit the requirements of your application.
         # For details, see https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+        startupProbe:
+          # The /startup probe returns OK when the proxy is ready to receive
+          # connections from the application. In this example, k8s will check
+          # once a second for 20 seconds.
+          #
+          # We strongly recommend adding a startup probe to the proxy sidecar
+          # container. This will ensure that service traffic will be routed to
+          # the pod only after the proxy has successfully started.
+          httpGet:
+            path: /startup
+            port: 9090
+          periodSeconds: 1
+          timeoutSeconds: 5
+          failureThreshold: 20
         livenessProbe:
+          # The /liveness probe returns OK as soon as the proxy application has
+          # begun its startup process and continues to return OK until the
+          # process stops.
+          #
+          # We recommend adding a liveness probe to the proxy sidecar container.
           httpGet:
             path: /liveness
             port: 9090
@@ -120,23 +139,31 @@ spec:
           # restarted.
           failureThreshold: 5
         readinessProbe:
+          # The /readiness probe returns OK when the proxy can establish
+          # a new connections to its databases.
+          #
+          # We do not recommend adding a readiness probe to the proxy sidecar
+          # container because it may cause unnecessary interruption to the
+          # application.
+          #
+          # This probe will fail when (1) the proxy used all its available
+          # concurrent connections to a database or (2) the network connection
+          # to the database is interrupted. These are transient states
+          # that resolve within a few seconds. However, if the readiness check
+          # fails too many times, k8s will kill the pod application container
+          # and the proxy container to be shut down. This is an undesirable
+          # result if the application is using a database connection
+          # pool with built-in resilience to transient failed connections.
           httpGet:
             path: /readiness
             port: 9090
-          initialDelaySeconds: 0
+          initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 5
+          timeoutSeconds: 10
           # Number of times the probe must report success to transition from failure to healthy state.
           # Defaults to 1 for readiness probe.
           successThreshold: 1
-          failureThreshold: 1
-        startupProbe:
-          httpGet:
-            path: /startup
-            port: 9090
-          periodSeconds: 1
-          timeoutSeconds: 5
-          failureThreshold: 20
+          failureThreshold: 6
       volumes:
       - name: <YOUR-SA-SECRET-VOLUME>
         secret:


### PR DESCRIPTION
This reorganizes and adds explanation to the startup and readiness probes. 

Also, this updates our recommendation to only use a startup and liveness probe, but not a readiness probe under most circumstances. 

Fixes #1757 