### PR TITLE
doc: Example now has a better security posture.

### DIFF
--- a/examples/k8s-health-check/proxy_with_http_health_check.yaml
+++ b/examples/k8s-health-check/proxy_with_http_health_check.yaml
@@ -79,6 +79,10 @@ spec:
           # The default Cloud SQL Auth Proxy image runs as the
           # "nonroot" user and group (uid: 65532) by default.
           runAsNonRoot: true
+          # Use a read-only filesystem
+          readOnlyRootFilesystem: true
+          # Do not allow privilege escalation
+          allowPrivilegeEscalation : false
         volumeMounts:
         - name: <YOUR-SA-SECRET-VOLUME>
           mountPath: /secrets/


### PR DESCRIPTION
This adds additional controls on the security context for pod containers to address these common
k8s security best practices:

Run as a non-root user
Mount container's root filesystem as read only
Restrict Container from acquiring additional privileges