### PR TITLE
fix: disallow auto-iam-authn with gcloud-auth

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -531,7 +531,7 @@ func parseConfig(cmd *Command, conf *proxy.Config, args []string) error {
 Instead use Application Default Credentials (enabled with: gcloud auth application-default login)
 and re-try with just --auto-iam-authn`)
 	}
-	if conf.LoginToken != "" && !conf.GcloudAuth && (conf.Token == "" || !conf.IAMAuthN) {
+	if conf.LoginToken != "" && (conf.Token == "" || !conf.IAMAuthN) {
 		return newBadCommandError("cannot specify --login-token without --token and --auto-iam-authn")
 	}
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -952,6 +952,12 @@ func TestNewCommandWithErrors(t *testing.T) {
 				"--gcloud-auth", "proj:region:inst"},
 		},
 		{
+			desc: "when both gcloud auth and auto-iam-authn are set",
+			args: []string{
+				"--auto-iam-authn",
+				"--gcloud-auth", "proj:region:inst"},
+		},
+		{
 			desc: "when both gcloud auth and credentials file are set",
 			args: []string{
 				"--gcloud-auth",


### PR DESCRIPTION
This combination is insecure because it puts an OAuth2 token with broader scoped access than necessary into the ephemeral certificate.

Because gcloud-auth is a legacy flag, it is generally discouraged. This commit also adds a note to make that clear and provides a clear alternative using Application Default Credentials.

Fixes #1754