### PR TITLE
chore: use `t.TempDir` to create temporary test directory

### DIFF
--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -100,25 +100,11 @@ func (*errorDialer) Close() error {
 	return errors.New("errorDialer returns error on Close")
 }
 
-func createTempDir(t *testing.T) (string, func()) {
-	testDir, err := os.MkdirTemp("", "*")
-	if err != nil {
-		t.Fatalf("failed to create temp dir: %v", err)
-	}
-	return testDir, func() {
-		if err := os.RemoveAll(testDir); err != nil {
-			t.Logf("failed to cleanup temp dir: %v", err)
-		}
-	}
-}
-
 func TestClientInitialization(t *testing.T) {
 	ctx := context.Background()
-	testDir, cleanup := createTempDir(t)
+	testDir := t.TempDir()
 	testUnixSocketPath := path.Join(testDir, "db")
 	testUnixSocketPathPg := path.Join(testDir, "db", ".s.PGSQL.5432")
-
-	defer cleanup()
 
 	tcs := []struct {
 		desc          string
@@ -518,8 +504,7 @@ func TestClientInitializationWorksRepeatedly(t *testing.T) {
 	// it on shutdown. This test ensures the existing socket does not cause
 	// problems for a second invocation.
 	ctx := context.Background()
-	testDir, cleanup := createTempDir(t)
-	defer cleanup()
+	testDir := t.TempDir()
 
 	in := &proxy.Config{
 		UnixSocket: testDir,
@@ -709,5 +694,4 @@ func TestRunConnectionCheck(t *testing.T) {
 	if err := verifyDialAttempts(); err != nil {
 		t.Fatal(err)
 	}
-
 }

--- a/tests/fuse_test.go
+++ b/tests/fuse_test.go
@@ -29,8 +29,7 @@ func TestPostgresFUSEConnect(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping Postgres integration tests")
 	}
-	tmpDir, cleanup := createTempDir(t)
-	defer cleanup()
+	tmpDir := t.TempDir()
 
 	host := proxy.UnixAddress(tmpDir, *postgresConnName)
 	dsn := fmt.Sprintf(
@@ -41,8 +40,7 @@ func TestPostgresFUSEConnect(t *testing.T) {
 }
 
 func testFUSE(t *testing.T, tmpDir, host string, dsn string) {
-	tmpDir2, cleanup2 := createTempDir(t)
-	defer cleanup2()
+	tmpDir2 := t.TempDir()
 
 	waitForFUSE := func() error {
 		var err error

--- a/tests/mysql_test.go
+++ b/tests/mysql_test.go
@@ -69,8 +69,7 @@ func TestMySQLUnix(t *testing.T) {
 		t.Skip("skipping MySQL integration tests")
 	}
 	requireMySQLVars(t)
-	tmpDir, cleanup := createTempDir(t)
-	defer cleanup()
+	tmpDir := t.TempDir()
 
 	cfg := mysql.Config{
 		User:                 *mysqlUser,

--- a/tests/postgres_test.go
+++ b/tests/postgres_test.go
@@ -66,8 +66,7 @@ func TestPostgresUnix(t *testing.T) {
 		t.Skip("skipping Postgres integration tests")
 	}
 	requirePostgresVars(t)
-	tmpDir, cleanup := createTempDir(t)
-	defer cleanup()
+	tmpDir := t.TempDir()
 
 	dsn := fmt.Sprintf("host=%s user=%s password=%s database=%s sslmode=disable",
 		// re-use utility function to determine the Unix address in a
@@ -77,18 +76,6 @@ func TestPostgresUnix(t *testing.T) {
 
 	proxyConnTest(t,
 		[]string{"--unix-socket", tmpDir, *postgresConnName}, "pgx", dsn)
-}
-
-func createTempDir(t *testing.T) (string, func()) {
-	testDir, err := os.MkdirTemp("", "*")
-	if err != nil {
-		t.Fatalf("failed to create temp dir: %v", err)
-	}
-	return testDir, func() {
-		if err := os.RemoveAll(testDir); err != nil {
-			t.Logf("failed to cleanup temp dir: %v", err)
-		}
-	}
 }
 
 func TestPostgresImpersonation(t *testing.T) {


### PR DESCRIPTION
This pull request replaces `os.MkdirTemp` with `t.TempDir` in tests. We can use the `t.TempDir` function from the `testing` package to create temporary directory. The directory created by `t.TempDir` is automatically removed when the test and all its subtests complete. 

Reference: https://pkg.go.dev/testing#T.TempDir

```go
func TestFoo(t *testing.T) {
	// before
	dir, err := os.MkdirTemp("", "")
	if err != nil {
		t.Fatal(err)
	}
	defer os.RemoveAll(dir)

	// now
	dir := t.TempDir()
}
```