### PR TITLE
chore: limit concurrent renovate PRs

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,5 +5,6 @@
   "commitMessagePrefix": "deps: ",
   "postUpdateOptions": [
     "gomodTidy"
-  ]
+  ],
+  "prConcurrentLimit": 3
 }


### PR DESCRIPTION
@enocom let's add this back in to not overcrowd open PRs with renovate and to avoid X builds running at the same time.