### PR TITLE
fix: remove the error message for zero on sigterm

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -886,6 +886,8 @@ func runSignalWrapper(cmd *Command) (err error) {
 		cmd.logger.Infof("SIGINT signal received. Shutting down...")
 	case errors.Is(err, errSigTerm):
 		cmd.logger.Infof("SIGTERM signal received. Shutting down...")
+	case errors.Is(err, errSigTermZero):
+		cmd.logger.Infof("SIGTERM signal received. Shutting down...")
 	case errors.Is(err, errQuitQuitQuit):
 		cmd.logger.Infof("/quitquitquit received request. Shutting down...")
 	default:


### PR DESCRIPTION
Print shutdown message instead of error for the zero on sigterm case. 

Fixes #1885 