### PR TITLE
chore: re-add bullseye tags

### DIFF
--- a/.build/release_artifacts.sh
+++ b/.build/release_artifacts.sh
@@ -80,9 +80,9 @@ tag_latest() {
         gcloud container images add-tag --quiet "$base_image:$new_version-buster" "$base_image:$major_minor_version-buster"
         gcloud container images add-tag --quiet "$base_image:$new_version-buster" "$base_image:$major_version-buster"
         echo "Addings tags to $new_version-bullseye image in $registry"
-        #gcloud container images add-tag --quiet "$base_image:$new_version-bullseye" "$base_image:bullseye"
-        #gcloud container images add-tag --quiet "$base_image:$new_version-bullseye" "$base_image:$major_minor_version-bullseye"
-        #gcloud container images add-tag --quiet "$base_image:$new_version-bullseye" "$base_image:$major_version-bullseye"
+        gcloud container images add-tag --quiet "$base_image:$new_version-bullseye" "$base_image:bullseye"
+        gcloud container images add-tag --quiet "$base_image:$new_version-bullseye" "$base_image:$major_minor_version-bullseye"
+        gcloud container images add-tag --quiet "$base_image:$new_version-bullseye" "$base_image:$major_version-bullseye"
     done
 }
 


### PR DESCRIPTION
Now that bullseye v1 build is working again we can re-add tags