### PR TITLE
feat: /quitquitquit api now responds to HTTP GET and POST requests.

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -913,7 +913,7 @@ func runSignalWrapper(cmd *Command) (err error) {
 
 func quitquitquit(quitOnce *sync.Once, shutdownCh chan<- error) http.HandlerFunc {
 	return func(rw http.ResponseWriter, req *http.Request) {
-		if req.Method != http.MethodPost {
+		if req.Method != http.MethodPost && req.Method != http.MethodGet {
 			rw.WriteHeader(400)
 			return
 		}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1307,7 +1307,7 @@ func TestPProfServer(t *testing.T) {
 	}
 }
 
-func TestQuitQuitQuit(t *testing.T) {
+func TestQuitQuitQuitHttpPost(t *testing.T) {
 	c := NewCommand(WithDialer(&spyDialer{}))
 	c.SilenceUsage = true
 	c.SilenceErrors = true
@@ -1320,7 +1320,7 @@ func TestQuitQuitQuit(t *testing.T) {
 		err := c.ExecuteContext(ctx)
 		errCh <- err
 	}()
-	resp, err := tryDial("GET", "http://localhost:9192/quitquitquit")
+	resp, err := tryDial("HEAD", "http://localhost:9192/quitquitquit")
 	if err != nil {
 		t.Fatalf("failed to dial endpoint: %v", err)
 	}
@@ -1328,6 +1328,41 @@ func TestQuitQuitQuit(t *testing.T) {
 		t.Fatalf("expected a 400 status, got = %v", resp.StatusCode)
 	}
 	resp, err = tryDial("POST", "http://localhost:9192/quitquitquit")
+	if err != nil {
+		t.Fatalf("failed to dial endpoint: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected a 200 status, got = %v", resp.StatusCode)
+	}
+
+	var gotErr error
+	select {
+	case err := <-errCh:
+		gotErr = err
+	case <-time.After(30 * time.Second):
+		t.Fatal("timeout waiting for error")
+	}
+
+	if !errors.Is(gotErr, errQuitQuitQuit) {
+		t.Fatalf("want = %v, got = %v", errQuitQuitQuit, gotErr)
+	}
+}
+
+func TestQuitQuitQuitHttpGet(t *testing.T) {
+	c := NewCommand(WithDialer(&spyDialer{}))
+	c.SilenceUsage = true
+	c.SilenceErrors = true
+	c.SetArgs([]string{"--quitquitquit", "--admin-port", "9192", "my-project:my-region:my-instance"})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errCh := make(chan error)
+	go func() {
+		err := c.ExecuteContext(ctx)
+		errCh <- err
+	}()
+
+	resp, err := tryDial("GET", "http://localhost:9192/quitquitquit")
 	if err != nil {
 		t.Fatalf("failed to dial endpoint: %v", err)
 	}


### PR DESCRIPTION
The /quitquitquit endpoint used to return a 400 error when it received a request other than an HTTP POST. Now, it 
will shut down the proxy if it receives either a GET or a POST request. This will make it possible for kubernetes
pod lifecycle handlers to gracefully signal the proxy to shut down.
 
Fixes #1946 