### PR TITLE
docs: Add kubernetes job example

### DIFF
--- a/examples/k8s-sidecar/job_with_shutdown_hook.yaml
+++ b/examples/k8s-sidecar/job_with_shutdown_hook.yaml
@@ -49,7 +49,7 @@ spec:
         - -c
         - >
           my_batch_job --host=127.0.0.1 --port=<DB_PORT> --username=<DB_USER> --dbname=<DB_NAME>
-          wget --post-data '' http://localhost:9091/quitquitquit
+          curl http://localhost:9091/quitquitquit
         image: busybox
         imagePullPolicy: IfNotPresent
         resources: {}

--- a/examples/k8s-sidecar/job_with_shutdown_hook.yaml
+++ b/examples/k8s-sidecar/job_with_shutdown_hook.yaml
@@ -1,0 +1,82 @@
+# Copyright 2023 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+###
+# This demonstrates how to configure a batch job so that it shuts down
+# the proxy containers when it has finished processing.
+#
+# The main job container should send a POST request to the proxy's /quitquitquit
+# api when the job process finishes. This will cause the proxy side-car
+# container to shut down.
+#
+# In Kubernetes 1.28, side-car containers will be properly supported, and this
+# extra step will become unnecessary.
+#
+# See https://github.com/kubernetes/enhancements/issues/753
+# and https://github.com/GoogleCloudPlatform/cloud-sql-proxy-operator/issues/381
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: job
+  labels:
+    app: busybox
+spec:
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: busybox
+    spec:
+      containers:
+      - name: my-application
+        # Run your batch job command.
+        # Then, send a HTTTP POST request to the proxy sidecar container's
+        # /quitquitquit api. This will cause the proxy process to exit.
+        command:
+        - sh
+        - -c
+        - >
+          my_batch_job --host=127.0.0.1 --port=<DB_PORT> --username=<DB_USER> --dbname=<DB_NAME>
+          wget --post-data '' http://localhost:9091/quitquitquit
+        image: busybox
+        imagePullPolicy: IfNotPresent
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      - name: cloud-sql-proxy
+        # It is recommended to use the latest version of the Cloud SQL Auth Proxy
+        # Make sure to update on a regular schedule!
+        image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.6.0
+        args:
+        # Enable the admin api server on port 9091
+        - "--admin-port=9091"
+        # Enable the /quitquitquit admin api endpoint
+        - "--quitquitquit"
+
+        # Tell the proxy to exit gracefully if it receives a SIGTERM
+        - "--exit-zero-on-sigterm"
+
+        # Replace DB_PORT with the port the proxy should listen on
+        - "--port=<DB_PORT>"
+        - "<INSTANCE_CONNECTION_NAME>"
+
+        securityContext:
+          runAsNonRoot: true
+        resources:
+          requests:
+            memory: "2Gi"
+            cpu:    "1"
+      restartPolicy: Never
+      terminationGracePeriodSeconds: 30


### PR DESCRIPTION
This example demonstrates how to use the /quitquitquit endpoint in a kubernetes job to allow job pods
to exit successfully when the main application container exits.

Fixes #1941 