### PR TITLE
fix: update supported Go versions

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.20"
+          go-version: "1.21"
 
       - name: Checkout base branch
         uses: actions/checkout@v3

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -27,7 +27,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v3
       with:
-        go-version: "1.20"
+        go-version: "1.21"
     - name: Install goimports
       run: go install golang.org/x/tools/cmd/goimports@latest
     - name: Checkout code

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -29,7 +29,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        go-version: ["1.17", "1.18", "1.19", "1.20"]
+        go-version: ["1.19", "1.21"]
       fail-fast: false
     permissions:
       contents: 'read'
@@ -125,7 +125,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.20"
+          go-version: "1.21"
 
       - id: 'auth'
         name: 'Authenticate to Google Cloud'


### PR DESCRIPTION
This matches https://github.com/googleapis/google-cloud-go#go-versions-supported