### PR TITLE
feat: add support for wait command

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -284,16 +284,16 @@ Waiting for Startup
 
     Sometimes it is necessary to wait for the Proxy to start.
 
-    To help ensure the Proxy is up and ready, the Proxy includes adds a wait
+    To help ensure the Proxy is up and ready, the Proxy includes a wait
     subcommand with an optional --max flag to set the maximum time to wait.
 
-    By default when invoking this command:
+    Invoke the wait command, like this:
 
     ./cloud-sql-proxy wait
 
-    The Proxy will wait up to the maximum time for the /startup endpoint to
-    respond. This command requires that the Proxy be started in another
-    process with the HTTP health check enabled. If an alternate health
+    By default, the Proxy will wait up to the maximum time for the startup
+    endpoint to respond. The wait command requires that the Proxy be started in
+    another process with the HTTP health check enabled. If an alternate health
     check port or address is used, as in:
 
     ./cloud-sql-proxy <INSTANCE_CONNECTION_NAME> \

--- a/cmd/wait_test.go
+++ b/cmd/wait_test.go
@@ -1,0 +1,61 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"net"
+	"testing"
+)
+
+func TestWaitCommandFlags(t *testing.T) {
+	ln, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+	host, port, err := net.SplitHostPort(ln.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		conn.Write([]byte("HTTP/1.1 200 OK\r\n\r\n"))
+	}()
+
+	_, err = invokeProxyCommand([]string{
+		"wait",
+		"--http-address", host,
+		"--http-port", port,
+		"--max=1s",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestWaitCommandFails(t *testing.T) {
+	_, err := invokeProxyCommand([]string{
+		"wait",
+		// assuming default host and port
+		"--max=500ms",
+	})
+	if err == nil {
+		t.Fatal("wait should fail when endpoint does not respond")
+	}
+}


### PR DESCRIPTION
To help ensure the Proxy is up and ready, this commit adds a wait command with an optional `--max` flag to set the maximum time to wait.

By default when invoking this command:

```
./cloud-sql-proxy wait
```

The Proxy will wait up to the maximum time for the /startup endpoint to respond. This command requires that the Proxy be started in another process with the HTTP health check enabled. If an alternate health check port or address is used, as in:

```
./cloud-sql-proxy <INSTANCE_CONNECTION_NAME> \
  --http-address 0.0.0.0 \
  --http-port 9191
```

Then the wait command must also be told to use the same custom values:

```
./cloud-sql-proxy wait \
  --http-address 0.0.0.0 \
  --http-port 9191
```

By default the wait command will wait 30 seconds. To alter this value, use:

```
./cloud-sql-proxy wait --max 10s
```

Fixes #1117