### PR TITLE
chore: `LABEL` Dockerfiles with URL of source repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,8 @@
 # Use the latest stable golang 1.x to compile to a binary
 FROM --platform=$BUILDPLATFORM golang:1 as build
 
+LABEL org.opencontainers.image.source="https://github.com/GoogleCloudPlatform/cloud-sql-proxy"
+
 WORKDIR /go/src/cloud-sql-proxy
 COPY . .
 

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -15,6 +15,8 @@
 # Use the latest stable golang 1.x to compile to a binary
 FROM --platform=$BUILDPLATFORM golang:1-alpine as build
 
+LABEL org.opencontainers.image.source="https://github.com/GoogleCloudPlatform/cloud-sql-proxy"
+
 WORKDIR /go/src/cloud-sql-proxy
 COPY . .
 

--- a/Dockerfile.bullseye
+++ b/Dockerfile.bullseye
@@ -15,6 +15,8 @@
 # Use the latest stable golang 1.x to compile to a binary
 FROM --platform=$BUILDPLATFORM golang:1 as build
 
+LABEL org.opencontainers.image.source="https://github.com/GoogleCloudPlatform/cloud-sql-proxy"
+
 WORKDIR /go/src/cloud-sql-proxy
 COPY . .
 

--- a/Dockerfile.buster
+++ b/Dockerfile.buster
@@ -15,6 +15,8 @@
 # Use the latest stable golang 1.x to compile to a binary
 FROM --platform=$BUILDPLATFORM golang:1 as build
 
+LABEL org.opencontainers.image.source="https://github.com/GoogleCloudPlatform/cloud-sql-proxy"
+
 WORKDIR /go/src/cloud-sql-proxy
 COPY . .
 


### PR DESCRIPTION
Currently, the `cloud-sql-proxy` Dockerfiles that are built and published on GCR do not have any `LABEL` statements. In my use case of the `cloud-sql-proxy` image, I want to pin the image to a specific version and use GitHub Dependabot to periodically update the image to the latest version. Dependabot currently cannot check for updates to the `cloud-sql-proxy` image because it does not have the `org.opencontainers.image.source` label.

This commit adds the line

```dockerfile
LABEL org.opencontainers.image.source="https://github.com/GoogleCloudPlatform/cloud-sql-proxy"
```

to the Dockerfiles that specify the image contents in the `cloud-sql-proxy` repository. This has the effect of allowing Dependabot to track updates to this image as documented [here](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#docker).

I'd love to hear any feedback on this request! I'm happy to adopt a different strategy for this work, my only goal is to make it possible to use Dependabot for `cloud-sql-proxy`. I'm also happy to create a tracking issue in this repo if anyone wants it. Thanks!