### PR TITLE
deps: update alpine image version to 3.18.5

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -28,7 +28,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
     go build -ldflags "-X github.com/GoogleCloudPlatform/cloud-sql-proxy/v2/cmd.metadataString=container.alpine"
 
 # Final stage
-FROM alpine:3@sha256:eece025e432126ce23f223450a0326fbebde39cdf496a85d8c016293fc851978
+FROM alpine:3@sha256:34871e7290500828b39e22294660bee86d966bc0017544e848dd9a255cdf59e0
 RUN apk add --no-cache \
     ca-certificates \
     libc6-compat


### PR DESCRIPTION
This alpine image version does not have CVE-2023-5363, CVE-2023-5678 vulnerabilities

<img width="1039" alt="image" src="https://github.com/GoogleCloudPlatform/cloud-sql-proxy/assets/1303176/d14a1264-e0dd-4012-90b0-45d3e4b8dcbd">

Related issue https://github.com/GoogleCloudPlatform/cloud-sql-proxy/issues/2048