### PR TITLE
chore: bump Proxy container examples to v2.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,13 +369,13 @@ currently supported:
 - `$VERSION-bullseye`
 
 The `$VERSION` is the Proxy version without the leading "v" (e.g.,
-`2.0.0`).
+`2.8.0`).
 
 For example, to pull a particular version, use a command like:
 
 ``` shell
-# $VERSION is 2.0.0
-docker pull gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.0.0
+# $VERSION is 2.8.0
+docker pull gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.8.0
 ```
 
 We recommend pinning to a specific version tag and using automation with a CI pipeline

--- a/examples/k8s-health-check/README.md
+++ b/examples/k8s-health-check/README.md
@@ -173,7 +173,7 @@ for more than 1 minute.
     - name: my-application
       image: gcr.io/my-container/my-application:1.1
     - name: cloud-sql-proxy
-      image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.1.0
+      image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.8.0
       args:
         # Set the --max-connections flag to 50
         - "--max-connections"

--- a/examples/k8s-health-check/proxy_with_http_health_check.yaml
+++ b/examples/k8s-health-check/proxy_with_http_health_check.yaml
@@ -49,7 +49,7 @@ spec:
       - name: cloud-sql-proxy
         # It is recommended to use the latest version of the Cloud SQL Auth Proxy
         # Make sure to update on a regular schedule!
-        image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.6.0
+        image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.8.0
         imagePullPolicy: IfNotPresent
 
         args:

--- a/examples/k8s-service/README.md
+++ b/examples/k8s-service/README.md
@@ -171,7 +171,7 @@ For the PgBouncer deployment, we add the proxy as a sidecar, starting it on port
 
 ``` yaml
 - name: cloud-sql-proxy
-  image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.0.0  # make sure to use the latest version
+  image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.8.0  # make sure to use the latest version
   args:
     # Replace DB_PORT with the port the proxy should listen on
     - "--port=<DB_PORT>"

--- a/examples/k8s-service/pgbouncer_deployment.yaml
+++ b/examples/k8s-service/pgbouncer_deployment.yaml
@@ -84,7 +84,7 @@ spec:
       - name: cloud-sql-proxy
         # It is recommended to use the latest version of the Cloud SQL Auth Proxy
         # Make sure to update on a regular schedule!
-        image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.1.0
+        image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.8.0
         args:
           - "--port=5431"
           - "<INSTANCE_CONNECTION_NAME>"

--- a/examples/k8s-sidecar/README.md
+++ b/examples/k8s-sidecar/README.md
@@ -182,7 +182,7 @@ as a separate service for several reasons:
     - name: cloud-sql-proxy
       # It is recommended to use the latest version of the Cloud SQL Auth Proxy
       # Make sure to update on a regular schedule!
-      image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.1.0  # make sure to use the latest version
+      image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.8.0  # make sure to use the latest version
       args:
         # If connecting from a VPC-native GKE cluster, you can use the
         # following flag to have the proxy connect over private IP

--- a/examples/k8s-sidecar/job_with_shutdown_hook.yaml
+++ b/examples/k8s-sidecar/job_with_shutdown_hook.yaml
@@ -58,7 +58,7 @@ spec:
       - name: cloud-sql-proxy
         # It is recommended to use the latest version of the Cloud SQL Auth Proxy
         # Make sure to update on a regular schedule!
-        image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.6.0
+        image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.8.0
         args:
         # Enable the admin api server on port 9091
         - "--admin-port=9091"

--- a/examples/k8s-sidecar/proxy_with_sa_key.yaml
+++ b/examples/k8s-sidecar/proxy_with_sa_key.yaml
@@ -47,7 +47,7 @@ spec:
       - name: cloud-sql-proxy
         # It is recommended to use the latest version of the Cloud SQL Auth Proxy
         # Make sure to update on a regular schedule!
-        image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.1.0
+        image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.8.0
         args:
           # If connecting from a VPC-native GKE cluster, you can use the
           # following flag to have the proxy connect over private IP

--- a/examples/k8s-sidecar/proxy_with_workload_identity.yaml
+++ b/examples/k8s-sidecar/proxy_with_workload_identity.yaml
@@ -53,7 +53,7 @@ spec:
       - name: cloud-sql-proxy
         # It is recommended to use the latest version of the Cloud SQL Auth Proxy
         # Make sure to update on a regular schedule!
-        image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.1.0
+        image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.8.0
         args:
           # If connecting from a VPC-native GKE cluster, you can use the
           # following flag to have the proxy connect over private IP


### PR DESCRIPTION
These examples are rendered into the official Google Cloud docs in certain code samples. Best to showcase our latest version if users decide to copy and paste without updating the version to latest.