### PR TITLE
chore: group deps by matchManagers

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,11 +11,11 @@
   "packageRules": [
     {
       "matchManagers": ["github-actions"],
-      "groupName": "bump dependencies for github"
+      "groupName": "dependencies for github"
     },
     {
       "matchManagers": ["dockerfile"],
-      "groupName": "bump container images"
+      "groupName": "container images"
     }
   ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,29 +10,12 @@
   "prConcurrentLimit": 3,
   "packageRules": [
     {
-      "matchPackagePatterns": [
-        "^actions/checkout",
-        "^actions/github-script",
-        "^actions/setup-go",
-        "^actions/upload-artifact",
-        "^dorny/paths-filter",
-        "^github/codeql-action",
-        "^golang/govulncheck-action",
-        "^golangci/golangci-lint-action",
-        "^google-github-actions/auth",
-        "^google-github-actions/get-secretmanager-secrets",
-        "^google-github-actions/setup-gcloud",
-        "^micnncim/action-label-syncer",
-        "^ossf/scorecard-action"
-      ],
-      "groupName": "dependencies for github"
+      "matchManagers": ["github-actions"],
+      "groupName": "bump dependencies for github"
     },
     {
-      "matchPackagePatterns": [
-        "^debian:buster",
-        "^debian:bullseye"
-      ],
-      "groupName": "container images"
+      "matchManagers": ["dockerfile"],
+      "groupName": "bump container images"
     }
   ]
 }


### PR DESCRIPTION
Leverage https://docs.renovatebot.com/modules/manager/#managers to group dep updates.

This will allow all base image SHA bumps to be grouped.