### PR TITLE
docs: improve documentation for subcommand

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -94,206 +94,217 @@ type Command struct {
 var longHelp = `
 Overview
 
-    The Cloud SQL Auth Proxy is a utility for ensuring secure connections to
-    your Cloud SQL instances. It provides IAM authorization, allowing you to
-    control who can connect to your instance through IAM permissions, and TLS
-    1.3 encryption, without having to manage certificates.
+  The Cloud SQL Auth Proxy is a utility for ensuring secure connections to
+  your Cloud SQL instances. It provides IAM authorization, allowing you to
+  control who can connect to your instance through IAM permissions, and TLS
+  1.3 encryption, without having to manage certificates.
 
-    NOTE: The Proxy does not configure the network. You MUST ensure the Proxy
-    can reach your Cloud SQL instance, either by deploying it in a VPC that has
-    access to your Private IP instance, or by configuring Public IP.
+  NOTE: The Proxy does not configure the network. You MUST ensure the Proxy
+  can reach your Cloud SQL instance, either by deploying it in a VPC that has
+  access to your Private IP instance, or by configuring Public IP.
 
-    For every provided instance connection name, the Proxy creates:
+  For every provided instance connection name, the Proxy creates:
 
-    - a socket that mimics a database running locally, and
-    - an encrypted connection using TLS 1.3 back to your Cloud SQL instance.
+  - a socket that mimics a database running locally, and
+  - an encrypted connection using TLS 1.3 back to your Cloud SQL instance.
 
-    The Proxy uses an ephemeral certificate to establish a secure connection to
-    your Cloud SQL instance. The Proxy will refresh those certificates on an
-    hourly basis. Existing client connections are unaffected by the refresh
-    cycle.
+  The Proxy uses an ephemeral certificate to establish a secure connection to
+  your Cloud SQL instance. The Proxy will refresh those certificates on an
+  hourly basis. Existing client connections are unaffected by the refresh
+  cycle.
 
 Starting the Proxy
 
-    To start the Proxy, you will need your instance connection name, which may
-    be found in the Cloud SQL instance overview page or by using gcloud with the
-    following command:
+  To start the Proxy, you will need your instance connection name, which may
+  be found in the Cloud SQL instance overview page or by using gcloud with the
+  following command:
 
-        gcloud sql instances describe INSTANCE --format='value(connectionName)'
+      gcloud sql instances describe INSTANCE --format='value(connectionName)'
 
-    For example, if your instance connection name is
-    "my-project:us-central1:my-db-server", starting the Proxy will be:
+  For example, if your instance connection name is
+  "my-project:us-central1:my-db-server", starting the Proxy will be:
 
-        ./cloud-sql-proxy my-project:us-central1:my-db-server
+      ./cloud-sql-proxy my-project:us-central1:my-db-server
 
-    By default, the Proxy will determine the database engine and start a
-    listener on localhost using the default database engine's port, i.e., MySQL
-    is 3306, Postgres is 5432, SQL Server is 1433. If multiple instances are
-    specified which all use the same database engine, the first will be started
-    on the default database port and subsequent instances will be incremented
-    from there (e.g., 3306, 3307, 3308, etc). To disable this behavior (and
-    reduce startup time), use the --port flag. All subsequent listeners will
-    increment from the provided value.
+  By default, the Proxy will determine the database engine and start a
+  listener on localhost using the default database engine's port, i.e., MySQL
+  is 3306, Postgres is 5432, SQL Server is 1433. If multiple instances are
+  specified which all use the same database engine, the first will be started
+  on the default database port and subsequent instances will be incremented
+  from there (e.g., 3306, 3307, 3308, etc). To disable this behavior (and
+  reduce startup time), use the --port flag. All subsequent listeners will
+  increment from the provided value.
 
-    All socket listeners use the localhost network interface. To override this
-    behavior, use the --address flag.
+  All socket listeners use the localhost network interface. To override this
+  behavior, use the --address flag.
 
 Instance Level Configuration
 
-    The Proxy supports overriding configuration on an instance-level with an
-    optional query string syntax using the corresponding full flag name. The
-    query string takes the form of a URL query string and should be appended to
-    the INSTANCE_CONNECTION_NAME, e.g.,
+  The Proxy supports overriding configuration on an instance-level with an
+  optional query string syntax using the corresponding full flag name. The
+  query string takes the form of a URL query string and should be appended to
+  the INSTANCE_CONNECTION_NAME, e.g.,
 
-        'my-project:us-central1:my-db-server?key1=value1&key2=value2'
+      'my-project:us-central1:my-db-server?key1=value1&key2=value2'
 
-    When using the optional query string syntax, quotes must wrap the instance
-    connection name and query string to prevent conflicts with the shell. For
-    example, to override the address and port for one instance but otherwise use
-    the default behavior, use:
+  When using the optional query string syntax, quotes must wrap the instance
+  connection name and query string to prevent conflicts with the shell. For
+  example, to override the address and port for one instance but otherwise use
+  the default behavior, use:
 
-        ./cloud-sql-proxy \
-    	    my-project:us-central1:my-db-server \
-    	    'my-project:us-central1:my-other-server?address=0.0.0.0&port=7000'
+      ./cloud-sql-proxy \
+  	    my-project:us-central1:my-db-server \
+  	    'my-project:us-central1:my-other-server?address=0.0.0.0&port=7000'
 
-    When necessary, you may specify the full path to a Unix socket. Set the
-    unix-socket-path query parameter to the absolute path of the Unix socket for
-    the database instance. The parent directory of the unix-socket-path must
-    exist when the Proxy starts or else socket creation will fail. For Postgres
-    instances, the Proxy will ensure that the last path element is
-    '.s.PGSQL.5432' appending it if necessary. For example,
+  When necessary, you may specify the full path to a Unix socket. Set the
+  unix-socket-path query parameter to the absolute path of the Unix socket for
+  the database instance. The parent directory of the unix-socket-path must
+  exist when the Proxy starts or else socket creation will fail. For Postgres
+  instances, the Proxy will ensure that the last path element is
+  '.s.PGSQL.5432' appending it if necessary. For example,
 
-        ./cloud-sql-proxy \
-          'my-project:us-central1:my-db-server?unix-socket-path=/path/to/socket'
+      ./cloud-sql-proxy \
+        'my-project:us-central1:my-db-server?unix-socket-path=/path/to/socket'
 
 Health checks
 
-    When enabling the --health-check flag, the Proxy will start an HTTP server
-    on localhost with three endpoints:
+  When enabling the --health-check flag, the Proxy will start an HTTP server
+  on localhost with three endpoints:
 
-    - /startup: Returns 200 status when the Proxy has finished starting up.
-    Otherwise returns 503 status.
+  - /startup: Returns 200 status when the Proxy has finished starting up.
+  Otherwise returns 503 status.
 
-    - /readiness: Returns 200 status when the Proxy has started, has available
-    connections if max connections have been set with the --max-connections
-    flag, and when the Proxy can connect to all registered instances. Otherwise,
-    returns a 503 status. Optionally supports a min-ready query param (e.g.,
-    /readiness?min-ready=3) where the Proxy will return a 200 status if the
-    Proxy can connect successfully to at least min-ready number of instances. If
-    min-ready exceeds the number of registered instances, returns a 400.
+  - /readiness: Returns 200 status when the Proxy has started, has available
+  connections if max connections have been set with the --max-connections
+  flag, and when the Proxy can connect to all registered instances. Otherwise,
+  returns a 503 status. Optionally supports a min-ready query param (e.g.,
+  /readiness?min-ready=3) where the Proxy will return a 200 status if the
+  Proxy can connect successfully to at least min-ready number of instances. If
+  min-ready exceeds the number of registered instances, returns a 400.
 
-    - /liveness: Always returns 200 status. If this endpoint is not responding,
-    the Proxy is in a bad state and should be restarted.
+  - /liveness: Always returns 200 status. If this endpoint is not responding,
+  the Proxy is in a bad state and should be restarted.
 
-    To configure the address, use --http-address. To configure the port, use
-    --http-port.
+  To configure the address, use --http-address. To configure the port, use
+  --http-port.
 
 Service Account Impersonation
 
-    The Proxy supports service account impersonation with the
-    --impersonate-service-account flag and matches gcloud's flag. When enabled,
-    all API requests are made impersonating the supplied service account. The
-    IAM principal must have the iam.serviceAccounts.getAccessToken permission or
-    the role roles/iam.serviceAccounts.serviceAccountTokenCreator.
+  The Proxy supports service account impersonation with the
+  --impersonate-service-account flag and matches gcloud's flag. When enabled,
+  all API requests are made impersonating the supplied service account. The
+  IAM principal must have the iam.serviceAccounts.getAccessToken permission or
+  the role roles/iam.serviceAccounts.serviceAccountTokenCreator.
 
-    For example:
+  For example:
 
-        ./cloud-sql-proxy \
-            --impersonate-service-account=impersonated@my-project.iam.gserviceaccount.com
-            my-project:us-central1:my-db-server
+      ./cloud-sql-proxy \
+          --impersonate-service-account=impersonated@my-project.iam.gserviceaccount.com
+          my-project:us-central1:my-db-server
 
-    In addition, the flag supports an impersonation delegation chain where the
-    value is a comma-separated list of service accounts. The first service
-    account in the list is the impersonation target. Each subsequent service
-    account is a delegate to the previous service account. When delegation is
-    used, each delegate must have the permissions named above on the service
-    account it is delegating to.
+  In addition, the flag supports an impersonation delegation chain where the
+  value is a comma-separated list of service accounts. The first service
+  account in the list is the impersonation target. Each subsequent service
+  account is a delegate to the previous service account. When delegation is
+  used, each delegate must have the permissions named above on the service
+  account it is delegating to.
 
-    For example:
+  For example:
 
-        ./cloud-sql-proxy \
-            --impersonate-service-account=SERVICE_ACCOUNT_1,SERVICE_ACCOUNT_2,SERVICE_ACCOUNT_3
-            my-project:us-central1:my-db-server
+      ./cloud-sql-proxy \
+          --impersonate-service-account=SERVICE_ACCOUNT_1,SERVICE_ACCOUNT_2,SERVICE_ACCOUNT_3
+          my-project:us-central1:my-db-server
 
-    In this example, the environment's IAM principal impersonates
-    SERVICE_ACCOUNT_3 which impersonates SERVICE_ACCOUNT_2 which then
-    impersonates the target SERVICE_ACCOUNT_1.
+  In this example, the environment's IAM principal impersonates
+  SERVICE_ACCOUNT_3 which impersonates SERVICE_ACCOUNT_2 which then
+  impersonates the target SERVICE_ACCOUNT_1.
 
 Configuration using environment variables
 
-    Instead of using CLI flags, the Proxy may be configured using environment
-    variables. Each environment variable uses "CSQL_PROXY" as a prefix and is
-    the uppercase version of the flag using underscores as word delimiters. For
-    example, the --auto-iam-authn flag may be set with the environment variable
-    CSQL_PROXY_AUTO_IAM_AUTHN. An invocation of the Proxy using environment
-    variables would look like the following:
+  Instead of using CLI flags, the Proxy may be configured using environment
+  variables. Each environment variable uses "CSQL_PROXY" as a prefix and is
+  the uppercase version of the flag using underscores as word delimiters. For
+  example, the --auto-iam-authn flag may be set with the environment variable
+  CSQL_PROXY_AUTO_IAM_AUTHN. An invocation of the Proxy using environment
+  variables would look like the following:
 
-        CSQL_PROXY_AUTO_IAM_AUTHN=true \
-            ./cloud-sql-proxy my-project:us-central1:my-db-server
+      CSQL_PROXY_AUTO_IAM_AUTHN=true \
+          ./cloud-sql-proxy my-project:us-central1:my-db-server
 
-    In addition to CLI flags, instance connection names may also be specified
-    with environment variables. If invoking the Proxy with only one instance
-    connection name, use CSQL_PROXY_INSTANCE_CONNECTION_NAME. For example:
+  In addition to CLI flags, instance connection names may also be specified
+  with environment variables. If invoking the Proxy with only one instance
+  connection name, use CSQL_PROXY_INSTANCE_CONNECTION_NAME. For example:
 
-        CSQL_PROXY_INSTANCE_CONNECTION_NAME=my-project:us-central1:my-db-server \
-            ./cloud-sql-proxy
+      CSQL_PROXY_INSTANCE_CONNECTION_NAME=my-project:us-central1:my-db-server \
+          ./cloud-sql-proxy
 
-    If multiple instance connection names are used, add the index of the
-    instance connection name as a suffix. For example:
+  If multiple instance connection names are used, add the index of the
+  instance connection name as a suffix. For example:
 
-        CSQL_PROXY_INSTANCE_CONNECTION_NAME_0=my-project:us-central1:my-db-server \
-        CSQL_PROXY_INSTANCE_CONNECTION_NAME_1=my-other-project:us-central1:my-other-server \
-            ./cloud-sql-proxy
+      CSQL_PROXY_INSTANCE_CONNECTION_NAME_0=my-project:us-central1:my-db-server \
+      CSQL_PROXY_INSTANCE_CONNECTION_NAME_1=my-other-project:us-central1:my-other-server \
+          ./cloud-sql-proxy
 
 Localhost Admin Server
 
-    The Proxy includes support for an admin server on localhost. By default,
-    the admin server is not enabled. To enable the server, pass the --debug or
-    --quitquitquit flag. This will start the server on localhost at port 9091.
-    To change the port, use the --admin-port flag.
+  The Proxy includes support for an admin server on localhost. By default,
+  the admin server is not enabled. To enable the server, pass the --debug or
+  --quitquitquit flag. This will start the server on localhost at port 9091.
+  To change the port, use the --admin-port flag.
 
-    When --debug is set, the admin server enables Go's profiler available at
-    /debug/pprof/.
+  When --debug is set, the admin server enables Go's profiler available at
+  /debug/pprof/.
 
-    See the documentation on pprof for details on how to use the
-    profiler at https://pkg.go.dev/net/http/pprof.
+  See the documentation on pprof for details on how to use the
+  profiler at https://pkg.go.dev/net/http/pprof.
 
-    When --quitquitquit is set, the admin server adds an endpoint at
-    /quitquitquit. The admin server exits gracefully when it receives a POST
-    request at /quitquitquit.
+  When --quitquitquit is set, the admin server adds an endpoint at
+  /quitquitquit. The admin server exits gracefully when it receives a POST
+  request at /quitquitquit.
 
 Waiting for Startup
 
-    Sometimes it is necessary to wait for the Proxy to start.
-
-    To help ensure the Proxy is up and ready, the Proxy includes a wait
-    subcommand with an optional --max flag to set the maximum time to wait.
-
-    Invoke the wait command, like this:
-
-    ./cloud-sql-proxy wait
-
-    By default, the Proxy will wait up to the maximum time for the startup
-    endpoint to respond. The wait command requires that the Proxy be started in
-    another process with the HTTP health check enabled. If an alternate health
-    check port or address is used, as in:
-
-    ./cloud-sql-proxy <INSTANCE_CONNECTION_NAME> \
-      --http-address 0.0.0.0 \
-      --http-port 9191
-
-    Then the wait command must also be told to use the same custom values:
-
-    ./cloud-sql-proxy wait \
-      --http-address 0.0.0.0 \
-      --http-port 9191
-
-    By default the wait command will wait 30 seconds. To alter this value,
-    use:
-
-    ./cloud-sql-proxy wait --max 10s
+  See the wait subcommand's help for details.
 
 (*) indicates a flag that may be used as a query parameter
+`
+
+var waitHelp = `
+Waiting for Proxy Startup
+
+  Sometimes it is necessary to wait for the Proxy to start.
+
+  To help ensure the Proxy is up and ready, the Proxy includes a wait
+  subcommand with an optional --max flag to set the maximum time to wait.
+  The wait command uses a separate Proxy's startup endpoint to determine
+  if the other Proxy process is ready.
+
+  Invoke the wait command, like this:
+
+  # waits for another Proxy process' startup endpoint to respond
+  ./cloud-sql-proxy wait
+
+Configuration
+
+  By default, the Proxy will wait up to the maximum time for the startup
+  endpoint to respond. The wait command requires that the Proxy be started in
+  another process with the HTTP health check enabled. If an alternate health
+  check port or address is used, as in:
+
+  ./cloud-sql-proxy <INSTANCE_CONNECTION_NAME> \
+    --http-address 0.0.0.0 \
+    --http-port 9191
+
+  Then the wait command must also be told to use the same custom values:
+
+  ./cloud-sql-proxy wait \
+    --http-address 0.0.0.0 \
+    --http-port 9191
+
+  By default the wait command will wait 30 seconds. To alter this value,
+  use:
+
+  ./cloud-sql-proxy wait --max 10s
 `
 
 const envPrefix = "CSQL_PROXY"
@@ -380,10 +391,12 @@ func NewCommand(opts ...Option) *Command {
 		},
 	}
 	var waitCmd = &cobra.Command{
-		Use:  "wait",
-		RunE: runWaitCmd,
+		Use:   "wait",
+		Short: "Wait for another Proxy process to start",
+		Long:  waitHelp,
+		RunE:  runWaitCmd,
 	}
-	waitFlags := waitCmd.PersistentFlags()
+	waitFlags := waitCmd.Flags()
 	waitFlags.DurationP(
 		waitMaxFlag, "m",
 		30*time.Second,
@@ -419,100 +432,101 @@ func NewCommand(opts ...Option) *Command {
 
 	rootCmd.RunE = func(*cobra.Command, []string) error { return runSignalWrapper(c) }
 
-	pflags := rootCmd.PersistentFlags()
+	// Flags that apply only to the root command
+	localFlags := rootCmd.Flags()
+	// Flags that applie to all sub-commands
+	globalFlags := rootCmd.PersistentFlags()
 
-	// Override Cobra's default messages.
-	pflags.BoolP("help", "h", false, "Display help information for cloud-sql-proxy")
-	pflags.BoolP("version", "v", false, "Print the cloud-sql-proxy version")
+	localFlags.BoolP("help", "h", false, "Display help information for cloud-sql-proxy")
+	localFlags.BoolP("version", "v", false, "Print the cloud-sql-proxy version")
 
-	// Global-only flags
-	pflags.StringVar(&c.conf.OtherUserAgents, "user-agent", "",
+	localFlags.StringVar(&c.conf.OtherUserAgents, "user-agent", "",
 		"Space separated list of additional user agents, e.g. cloud-sql-proxy-operator/0.0.1")
-	pflags.StringVarP(&c.conf.Token, "token", "t", "",
+	localFlags.StringVarP(&c.conf.Token, "token", "t", "",
 		"Use bearer token as a source of IAM credentials.")
-	pflags.StringVar(&c.conf.LoginToken, "login-token", "",
+	localFlags.StringVar(&c.conf.LoginToken, "login-token", "",
 		"Use bearer token as a database password (used with token and auto-iam-authn only)")
-	pflags.StringVarP(&c.conf.CredentialsFile, "credentials-file", "c", "",
+	localFlags.StringVarP(&c.conf.CredentialsFile, "credentials-file", "c", "",
 		"Use service account key file as a source of IAM credentials.")
-	pflags.StringVarP(&c.conf.CredentialsJSON, "json-credentials", "j", "",
+	localFlags.StringVarP(&c.conf.CredentialsJSON, "json-credentials", "j", "",
 		"Use service account key JSON as a source of IAM credentials.")
-	pflags.BoolVarP(&c.conf.GcloudAuth, "gcloud-auth", "g", false,
+	localFlags.BoolVarP(&c.conf.GcloudAuth, "gcloud-auth", "g", false,
 		`Use gcloud's user credentials as a source of IAM credentials.
 NOTE: this flag is a legacy feature and generally should not be used.
 Instead prefer Application Default Credentials
 (enabled with: gcloud auth application-default login) which
 the Proxy will then pick-up automatically.`)
-	pflags.BoolVarP(&c.conf.StructuredLogs, "structured-logs", "l", false,
+	localFlags.BoolVarP(&c.conf.StructuredLogs, "structured-logs", "l", false,
 		"Enable structured logging with LogEntry format")
-	pflags.Uint64Var(&c.conf.MaxConnections, "max-connections", 0,
+	localFlags.Uint64Var(&c.conf.MaxConnections, "max-connections", 0,
 		"Limit the number of connections. Default is no limit.")
-	pflags.DurationVar(&c.conf.WaitOnClose, "max-sigterm-delay", 0,
+	localFlags.DurationVar(&c.conf.WaitOnClose, "max-sigterm-delay", 0,
 		"Maximum number of seconds to wait for connections to close after receiving a TERM signal.")
-	pflags.StringVar(&c.conf.TelemetryProject, "telemetry-project", "",
+	localFlags.StringVar(&c.conf.TelemetryProject, "telemetry-project", "",
 		"Enable Cloud Monitoring and Cloud Trace with the provided project ID.")
-	pflags.BoolVar(&c.conf.DisableTraces, "disable-traces", false,
+	localFlags.BoolVar(&c.conf.DisableTraces, "disable-traces", false,
 		"Disable Cloud Trace integration (used with --telemetry-project)")
-	pflags.IntVar(&c.conf.TelemetryTracingSampleRate, "telemetry-sample-rate", 10_000,
+	localFlags.IntVar(&c.conf.TelemetryTracingSampleRate, "telemetry-sample-rate", 10_000,
 		"Set the Cloud Trace sample rate. A smaller number means more traces.")
-	pflags.BoolVar(&c.conf.DisableMetrics, "disable-metrics", false,
+	localFlags.BoolVar(&c.conf.DisableMetrics, "disable-metrics", false,
 		"Disable Cloud Monitoring integration (used with --telemetry-project)")
-	pflags.StringVar(&c.conf.TelemetryPrefix, "telemetry-prefix", "",
+	localFlags.StringVar(&c.conf.TelemetryPrefix, "telemetry-prefix", "",
 		"Prefix for Cloud Monitoring metrics.")
-	pflags.BoolVar(&c.conf.ExitZeroOnSigterm, "exit-zero-on-sigterm", false,
+	localFlags.BoolVar(&c.conf.ExitZeroOnSigterm, "exit-zero-on-sigterm", false,
 		"Exit with 0 exit code when Sigterm received (default is 143)")
-	pflags.BoolVar(&c.conf.Prometheus, "prometheus", false,
+	localFlags.BoolVar(&c.conf.Prometheus, "prometheus", false,
 		"Enable Prometheus HTTP endpoint /metrics on localhost")
-	pflags.StringVar(&c.conf.PrometheusNamespace, "prometheus-namespace", "",
+	localFlags.StringVar(&c.conf.PrometheusNamespace, "prometheus-namespace", "",
 		"Use the provided Prometheus namespace for metrics")
-	pflags.StringVar(&c.conf.HTTPAddress, httpAddressFlag, "localhost",
+	globalFlags.StringVar(&c.conf.HTTPAddress, httpAddressFlag, "localhost",
 		"Address for Prometheus and health check server")
-	pflags.StringVar(&c.conf.HTTPPort, httpPortFlag, "9090",
+	globalFlags.StringVar(&c.conf.HTTPPort, httpPortFlag, "9090",
 		"Port for Prometheus and health check server")
-	pflags.BoolVar(&c.conf.Debug, "debug", false,
+	localFlags.BoolVar(&c.conf.Debug, "debug", false,
 		"Enable pprof on the localhost admin server")
-	pflags.BoolVar(&c.conf.QuitQuitQuit, "quitquitquit", false,
+	localFlags.BoolVar(&c.conf.QuitQuitQuit, "quitquitquit", false,
 		"Enable quitquitquit endpoint on the localhost admin server")
-	pflags.StringVar(&c.conf.AdminPort, "admin-port", "9091",
+	localFlags.StringVar(&c.conf.AdminPort, "admin-port", "9091",
 		"Port for localhost-only admin server")
-	pflags.BoolVar(&c.conf.HealthCheck, "health-check", false,
+	localFlags.BoolVar(&c.conf.HealthCheck, "health-check", false,
 		"Enables health check endpoints /startup, /liveness, and /readiness on localhost.")
-	pflags.StringVar(&c.conf.APIEndpointURL, "sqladmin-api-endpoint", "",
+	localFlags.StringVar(&c.conf.APIEndpointURL, "sqladmin-api-endpoint", "",
 		"API endpoint for all Cloud SQL Admin API requests. (default: https://sqladmin.googleapis.com)")
-	pflags.StringVar(&c.conf.QuotaProject, "quota-project", "",
+	localFlags.StringVar(&c.conf.QuotaProject, "quota-project", "",
 		`Specifies the project to use for Cloud SQL Admin API quota tracking.
 The IAM principal must have the "serviceusage.services.use" permission
 for the given project. See https://cloud.google.com/service-usage/docs/overview and
 https://cloud.google.com/storage/docs/requester-pays`)
-	pflags.StringVar(&c.conf.FUSEDir, "fuse", "",
+	localFlags.StringVar(&c.conf.FUSEDir, "fuse", "",
 		"Mount a directory at the path using FUSE to access Cloud SQL instances.")
-	pflags.StringVar(&c.conf.FUSETempDir, "fuse-tmp-dir",
+	localFlags.StringVar(&c.conf.FUSETempDir, "fuse-tmp-dir",
 		filepath.Join(os.TempDir(), "csql-tmp"),
 		"Temp dir for Unix sockets created with FUSE")
-	pflags.StringVar(&c.conf.ImpersonationChain, "impersonate-service-account", "",
+	localFlags.StringVar(&c.conf.ImpersonationChain, "impersonate-service-account", "",
 		`Comma separated list of service accounts to impersonate. Last value
 is the target account.`)
-	rootCmd.PersistentFlags().BoolVar(&c.conf.Quiet, "quiet", false, "Log error messages only")
-	pflags.BoolVar(&c.conf.AutoIP, "auto-ip", false,
+	localFlags.BoolVar(&c.conf.Quiet, "quiet", false, "Log error messages only")
+	localFlags.BoolVar(&c.conf.AutoIP, "auto-ip", false,
 		`Supports legacy behavior of v1 and will try to connect to first IP
 address returned by the SQL Admin API. In most cases, this flag should not be used.
 Prefer default of public IP or use --private-ip instead.`)
 
-	pflags.BoolVar(&c.conf.RunConnectionTest, "run-connection-test", false, `Runs a connection test
+	localFlags.BoolVar(&c.conf.RunConnectionTest, "run-connection-test", false, `Runs a connection test
 against all specified instances. If an instance is unreachable, the Proxy exits with a failure
 status code.`)
 
 	// Global and per instance flags
-	pflags.StringVarP(&c.conf.Addr, "address", "a", "127.0.0.1",
+	localFlags.StringVarP(&c.conf.Addr, "address", "a", "127.0.0.1",
 		"(*) Address to bind Cloud SQL instance listeners.")
-	pflags.IntVarP(&c.conf.Port, "port", "p", 0,
+	localFlags.IntVarP(&c.conf.Port, "port", "p", 0,
 		"(*) Initial port for listeners. Subsequent listeners increment from this value.")
-	pflags.StringVarP(&c.conf.UnixSocket, "unix-socket", "u", "",
+	localFlags.StringVarP(&c.conf.UnixSocket, "unix-socket", "u", "",
 		`(*) Enables Unix sockets for all listeners with the provided directory.`)
-	pflags.BoolVarP(&c.conf.IAMAuthN, "auto-iam-authn", "i", false,
+	localFlags.BoolVarP(&c.conf.IAMAuthN, "auto-iam-authn", "i", false,
 		"(*) Enables Automatic IAM Authentication for all instances")
-	pflags.BoolVar(&c.conf.PrivateIP, "private-ip", false,
+	localFlags.BoolVar(&c.conf.PrivateIP, "private-ip", false,
 		"(*) Connect to the private ip address for all instances")
-	pflags.BoolVar(&c.conf.PSC, "psc", false,
+	localFlags.BoolVar(&c.conf.PSC, "psc", false,
 		"(*) Connect to the PSC endpoint for all instances")
 
 	v := viper.NewWithOptions(viper.EnvKeyReplacer(strings.NewReplacer("-", "_")))
@@ -520,18 +534,33 @@ status code.`)
 	v.AutomaticEnv()
 	// Ignoring the error here since its only occurence is if one of the pflags
 	// is nil which is never the case here.
-	_ = v.BindPFlags(pflags)
+	_ = v.BindPFlags(globalFlags)
+	_ = v.BindPFlags(localFlags)
 
-	pflags.VisitAll(func(f *pflag.Flag) {
-		// Override any unset flags with Viper values to use the pflags
-		// object as a single source of truth.
+	// Override any unset flags with Viper values to use the pflags
+	// object as a single source of truth.
+	localFlags.VisitAll(func(f *pflag.Flag) {
 		if !f.Changed && v.IsSet(f.Name) {
 			val := v.Get(f.Name)
-			_ = pflags.Set(f.Name, fmt.Sprintf("%v", val))
+			_ = localFlags.Set(f.Name, fmt.Sprintf("%v", val))
+		}
+	})
+	globalFlags.VisitAll(func(f *pflag.Flag) {
+		if !f.Changed && v.IsSet(f.Name) {
+			val := v.Get(f.Name)
+			_ = globalFlags.Set(f.Name, fmt.Sprintf("%v", val))
 		}
 	})
 
 	return c
+}
+
+func userHasSetLocal(cmd *Command, f string) bool {
+	return cmd.LocalFlags().Lookup(f).Changed
+}
+
+func userHasSetGlobal(cmd *Command, f string) bool {
+	return cmd.PersistentFlags().Lookup(f).Changed
 }
 
 func parseConfig(cmd *Command, conf *proxy.Config, args []string) error {
@@ -557,19 +586,16 @@ func parseConfig(cmd *Command, conf *proxy.Config, args []string) error {
 		return newBadCommandError("cannot specify --fuse-tmp-dir without --fuse")
 	}
 
-	userHasSet := func(f string) bool {
-		return cmd.PersistentFlags().Lookup(f).Changed
-	}
-	if userHasSet("address") && userHasSet("unix-socket") {
+	if userHasSetLocal(cmd, "address") && userHasSetLocal(cmd, "unix-socket") {
 		return newBadCommandError("cannot specify --unix-socket and --address together")
 	}
-	if userHasSet("port") && userHasSet("unix-socket") {
+	if userHasSetLocal(cmd, "port") && userHasSetLocal(cmd, "unix-socket") {
 		return newBadCommandError("cannot specify --unix-socket and --port together")
 	}
 	if ip := net.ParseIP(conf.Addr); ip == nil {
 		return newBadCommandError(fmt.Sprintf("not a valid IP address: %q", conf.Addr))
 	}
-	if userHasSet("private-ip") && userHasSet("auto-ip") {
+	if userHasSetLocal(cmd, "private-ip") && userHasSetLocal(cmd, "auto-ip") {
 		return newBadCommandError("cannot specify --private-ip and --auto-ip together")
 	}
 
@@ -612,26 +638,26 @@ and re-try with just --auto-iam-authn`)
 		return newBadCommandError("cannot specify --login-token without --token and --auto-iam-authn")
 	}
 
-	if userHasSet("http-port") && !userHasSet("prometheus") && !userHasSet("health-check") {
+	if userHasSetGlobal(cmd, "http-port") && !userHasSetLocal(cmd, "prometheus") && !userHasSetLocal(cmd, "health-check") {
 		cmd.logger.Infof("Ignoring --http-port because --prometheus or --health-check was not set")
 	}
 
-	if !userHasSet("telemetry-project") && userHasSet("telemetry-prefix") {
+	if !userHasSetLocal(cmd, "telemetry-project") && userHasSetLocal(cmd, "telemetry-prefix") {
 		cmd.logger.Infof("Ignoring --telementry-prefix because --telemetry-project was not set")
 	}
-	if !userHasSet("telemetry-project") && userHasSet("disable-metrics") {
+	if !userHasSetLocal(cmd, "telemetry-project") && userHasSetLocal(cmd, "disable-metrics") {
 		cmd.logger.Infof("Ignoring --disable-metrics because --telemetry-project was not set")
 	}
-	if !userHasSet("telemetry-project") && userHasSet("disable-traces") {
+	if !userHasSetLocal(cmd, "telemetry-project") && userHasSetLocal(cmd, "disable-traces") {
 		cmd.logger.Infof("Ignoring --disable-traces because --telemetry-project was not set")
 	}
 
-	if userHasSet("user-agent") {
+	if userHasSetLocal(cmd, "user-agent") {
 		userAgent += " " + cmd.conf.OtherUserAgents
 		conf.UserAgent = userAgent
 	}
 
-	if userHasSet("sqladmin-api-endpoint") && conf.APIEndpointURL != "" {
+	if userHasSetLocal(cmd, "sqladmin-api-endpoint") && conf.APIEndpointURL != "" {
 		_, err := url.Parse(conf.APIEndpointURL)
 		if err != nil {
 			return newBadCommandError(fmt.Sprintf(


### PR DESCRIPTION
This commit adds docs for the wait subcommand and organizes the flags to correctly reflect what can be set on the subcommand and what cannot be.

Fixes #2082