### PR TITLE
chore: add WithDebugLogging Option

### DIFF
--- a/cmd/options.go
+++ b/cmd/options.go
@@ -82,3 +82,10 @@ func WithQuietLogging() Option {
 		c.conf.Quiet = true
 	}
 }
+
+// WithDebugLogging configures the Proxy to log debug level messages.
+func WithDebugLogging() Option {
+	return func(c *Command) {
+		c.conf.DebugLogs = true
+	}
+}

--- a/internal/proxy/proxy_other.go
+++ b/internal/proxy/proxy_other.go
@@ -112,11 +112,11 @@ func (c *Client) Lookup(ctx context.Context, instance string, _ *fuse.EntryOut) 
 	c.fuseMu.Lock()
 	defer c.fuseMu.Unlock()
 	if l, ok := c.fuseSockets[instance]; ok {
-		c.logger.Debugf("found existing fuse socket for instance %q", instance)
+		c.logger.Debugf("found existing socket for instance %q", instance)
 		return l.symlink.EmbeddedInode(), fs.OK
 	}
 
-	c.logger.Debugf("creating new fuse socket for instance %q", instance)
+	c.logger.Debugf("creating new socket for instance %q", instance)
 	s, err := c.newSocketMount(
 		ctx, withUnixSocket(*c.conf, c.fuseTempDir),
 		nil, InstanceConnConfig{Name: instance},


### PR DESCRIPTION
Add Option `WithDebugLogging` to allow users starting proxy with `NewCommand` to enable debug logging.

Improve debug logging for fuse path with additional debug log messages.