### PR TITLE
chore: revert "feat: use Google managed base images"

### DIFF
--- a/Dockerfile.bullseye
+++ b/Dockerfile.bullseye
@@ -26,7 +26,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
     go build -ldflags "-X github.com/GoogleCloudPlatform/cloud-sql-proxy/v2/cmd.metadataString=container.bullseye"
 
 # Final stage
-FROM gcr.io/cloud-marketplace/google/debian11@sha256:97c05bb689107b51ac5c1656d8001db175ee2c214897ab6d51d74dc2a2db5023
+FROM debian:bullseye@sha256:5a87974e73c64b3fb161d444a84bdd47c0e6b6058eacaeea64342e7cbce1f04d
 
 LABEL org.opencontainers.image.source="https://github.com/GoogleCloudPlatform/cloud-sql-proxy"
 

--- a/Dockerfile.buster
+++ b/Dockerfile.buster
@@ -26,7 +26,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
     go build -ldflags "-X github.com/GoogleCloudPlatform/cloud-sql-proxy/v2/cmd.metadataString=container.buster"
 
 # Final stage
-FROM gcr.io/cloud-marketplace/google/debian10@sha256:c583011c5370f62f33116fcb214de8c4665b5dc4bf40e2a9157361474647f27f
+FROM debian:buster@sha256:f6b3b7c7b049c2c7d0f19ae988b4eac64fd8e127fa891c9de1d3cf3f8c33cad4
 
 LABEL org.opencontainers.image.source="https://github.com/GoogleCloudPlatform/cloud-sql-proxy"
 


### PR DESCRIPTION
Reverts GoogleCloudPlatform/cloud-sql-proxy#2159

The managed containers don't build for arm64. Revert this change until we can be certain
all architectures currently supported, remain supported.