### PR TITLE
feat: use Google managed Debian containers

### DIFF
--- a/Dockerfile.bullseye
+++ b/Dockerfile.bullseye
@@ -26,7 +26,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
     go build -ldflags "-X main.metadataString=container.bullseye" -o cloud_sql_proxy ./cmd/cloud_sql_proxy
 
 # Final stage
-FROM debian:bullseye
+FROM gcr.io/cloud-marketplace/google/debian11
 RUN apt-get update && apt-get install -y ca-certificates
 # Install fuse and allow enable non-root users to mount
 RUN apt-get update && apt-get install -y fuse && sed -i 's/^#user_allow_other$/user_allow_other/g' /etc/fuse.conf

--- a/Dockerfile.buster
+++ b/Dockerfile.buster
@@ -26,7 +26,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
     go build -ldflags "-X main.metadataString=container.buster" -o cloud_sql_proxy ./cmd/cloud_sql_proxy
 
 # Final stage
-FROM debian:buster
+FROM gcr.io/cloud-marketplace/google/debian10
 RUN apt-get update && apt-get install -y ca-certificates
 # Install fuse and allow enable non-root users to mount
 RUN apt-get update && apt-get install -y fuse && sed -i 's/^#user_allow_other$/user_allow_other/g' /etc/fuse.conf


### PR DESCRIPTION
This is a port of https://github.com/GoogleCloudPlatform/cloud-sql-proxy/pull/2159 for the v1 branch.