### PR TITLE
chore: run govulncheck on v1 PRs

### DIFF
--- a/.github/workflows/govulncheck.yaml
+++ b/.github/workflows/govulncheck.yaml
@@ -23,6 +23,9 @@ on:
     - 'main'
     - 'v1'
   pull_request:
+    branches:
+      - 'main'
+      - 'v1'
   pull_request_target:
     types: [labeled]
   schedule:


### PR DESCRIPTION
Allow govulncheck to run on PRs to v1 branch 