### PR TITLE
fix: use public mirrors for base images

### DIFF
--- a/Dockerfile.bullseye
+++ b/Dockerfile.bullseye
@@ -26,7 +26,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
     go build -ldflags "-X github.com/GoogleCloudPlatform/cloud-sql-proxy/v2/cmd.metadataString=container.bullseye"
 
 # Final stage
-FROM gcr.io/cloud-marketplace/google/debian11@sha256:97c05bb689107b51ac5c1656d8001db175ee2c214897ab6d51d74dc2a2db5023
+FROM gcr.io/cloud-marketplace-containers/google/debian11@sha256:97c05bb689107b51ac5c1656d8001db175ee2c214897ab6d51d74dc2a2db5023
 
 LABEL org.opencontainers.image.source="https://github.com/GoogleCloudPlatform/cloud-sql-proxy"
 

--- a/Dockerfile.buster
+++ b/Dockerfile.buster
@@ -26,7 +26,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
     go build -ldflags "-X github.com/GoogleCloudPlatform/cloud-sql-proxy/v2/cmd.metadataString=container.buster"
 
 # Final stage
-FROM gcr.io/cloud-marketplace/google/debian10@sha256:c583011c5370f62f33116fcb214de8c4665b5dc4bf40e2a9157361474647f27f
+FROM gcr.io/cloud-marketplace-containers/google/debian10@sha256:c583011c5370f62f33116fcb214de8c4665b5dc4bf40e2a9157361474647f27f
 
 LABEL org.opencontainers.image.source="https://github.com/GoogleCloudPlatform/cloud-sql-proxy"
 


### PR DESCRIPTION
This is a port of https://github.com/GoogleCloudPlatform/alloydb-auth-proxy/pull/627