### PR TITLE
fix: ensure proxy shutsdown cleanly on fuse error

### DIFF
--- a/internal/proxy/proxy_other.go
+++ b/internal/proxy/proxy_other.go
@@ -184,6 +184,9 @@ func (c *Client) fuseMounts() []*socketMount {
 func (c *Client) unmountFUSE() error {
 	c.fuseServerMu.Lock()
 	defer c.fuseServerMu.Unlock()
+	if c.fuseServer == nil {
+		return nil
+	}
 	return c.fuseServer.Unmount()
 }
 

--- a/internal/proxy/proxy_other_test.go
+++ b/internal/proxy/proxy_other_test.go
@@ -18,8 +18,11 @@
 package proxy_test
 
 import (
+	"context"
 	"os"
 	"testing"
+
+	"github.com/GoogleCloudPlatform/cloud-sql-proxy/v2/internal/proxy"
 )
 
 var (
@@ -39,4 +42,21 @@ func verifySocketPermissions(t *testing.T, addr string) {
 	if fm := fi.Mode(); fm != 0777|os.ModeSocket {
 		t.Fatalf("file mode: want = %v, got = %v", 0777|os.ModeSocket, fm)
 	}
+}
+
+func TestFuseClosesGracefully(t *testing.T) {
+	c, err := proxy.NewClient(
+		context.Background(), nil, testLogger,
+		&proxy.Config{
+			FUSEDir:     t.TempDir(),
+			FUSETempDir: t.TempDir(),
+			Token:       "mytoken",
+		})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Close(); err != nil {
+		t.Fatal(err)
+	}
+
 }


### PR DESCRIPTION
If the fuse server fails to mount, the call to Close should not panic. This commit ensures that no panic's happen if fuse isn't properly configured.

Fixes #2013