### PR TITLE
fix: don't depend on downstream in readiness check

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1062,8 +1062,10 @@ func runSignalWrapper(cmd *Command) (err error) {
 	var (
 		needsHTTPServer bool
 		mux             = http.NewServeMux()
-		notify          = func() {}
+		notifyStarted   = func() {}
+		notifyStopped   = func() {}
 	)
+
 	if cmd.conf.Prometheus {
 		needsHTTPServer = true
 		e, err := prometheus.NewExporter(prometheus.Options{
@@ -1083,8 +1085,10 @@ func runSignalWrapper(cmd *Command) (err error) {
 		mux.HandleFunc("/startup", hc.HandleStartup)
 		mux.HandleFunc("/readiness", hc.HandleReadiness)
 		mux.HandleFunc("/liveness", hc.HandleLiveness)
-		notify = hc.NotifyStarted
+		notifyStarted = hc.NotifyStarted
+		notifyStopped = hc.NotifyStopped
 	}
+	defer notifyStopped()
 	// Start the HTTP server if anything requiring HTTP is specified.
 	if needsHTTPServer {
 		go startHTTPServer(
@@ -1127,7 +1131,7 @@ func runSignalWrapper(cmd *Command) (err error) {
 		)
 	}
 
-	go func() { shutdownCh <- p.Serve(ctx, notify) }()
+	go func() { shutdownCh <- p.Serve(ctx, notifyStarted) }()
 
 	err = <-shutdownCh
 	switch {


### PR DESCRIPTION
The readiness probe should not depend on downstream connections. Doing so can cause unwanted downtime. See [1]. This commit removes all dialing of downstream database servers as a result.

In addition, after the Proxy receives a SIGTERM or SIGINT, the readiness check will now report an unhealthy status to ensure it is removed from circulation before shutdown completes.

[1]: https://github.com/zegl/kube-score/blob/master/README_PROBES.md#readinessprobe

Fixes #2083