### PR TITLE
chore: add debug logs around shutdownCh

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1025,6 +1025,7 @@ func runSignalWrapper(cmd *Command) (err error) {
 		defer close(startCh)
 		p, err := proxy.NewClient(ctx, cmd.dialer, cmd.logger, cmd.conf)
 		if err != nil {
+			cmd.logger.Debugf("Error starting proxy. Writing error to shutdown channel.")
 			shutdownCh <- fmt.Errorf("unable to start: %v", err)
 			return
 		}
@@ -1129,7 +1130,10 @@ func runSignalWrapper(cmd *Command) (err error) {
 		)
 	}
 
-	go func() { shutdownCh <- p.Serve(ctx, notify) }()
+	go func() { 
+		cmd.logger.Debugf("Starting to listen on shutdown channel.")
+		shutdownCh <- p.Serve(ctx, notify) 
+	}()
 
 	err = <-shutdownCh
 	switch {
@@ -1159,6 +1163,7 @@ func quitquitquit(quitOnce *sync.Once, shutdownCh chan<- error) http.HandlerFunc
 			default:
 				// The write attempt to shutdownCh failed and
 				// the proxy is already exiting.
+				cmd.logger.Debugf("Could not write to shutdown channel. The proxy is already exiting.")
 			}
 		})
 	}
@@ -1176,6 +1181,7 @@ func startHTTPServer(ctx context.Context, l cloudsql.Logger, addr string, mux *h
 			return
 		}
 		if err != nil {
+			cmd.logger.Debugf("Error starting HTTP server. Writing error to shutdown channel.")
 			shutdownCh <- fmt.Errorf("failed to start HTTP server: %v", err)
 		}
 	}()

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1025,7 +1025,7 @@ func runSignalWrapper(cmd *Command) (err error) {
 		defer close(startCh)
 		p, err := proxy.NewClient(ctx, cmd.dialer, cmd.logger, cmd.conf)
 		if err != nil {
-			cmd.logger.Debugf("Error starting proxy. Writing error to shutdown channel.")
+			cmd.logger.Debugf("Error starting proxy: %v", err)
 			shutdownCh <- fmt.Errorf("unable to start: %v", err)
 			return
 		}
@@ -1135,8 +1135,9 @@ func runSignalWrapper(cmd *Command) (err error) {
 	}
 
 	go func() {
-		cmd.logger.Debugf("Starting to listen on shutdown channel.")
-		shutdownCh <- p.Serve(ctx, notifyStarted)
+		err := p.Serve(ctx, notifyStarted)
+		cmd.logger.Debugf("proxy server error: %v", err)
+		shutdownCh <- err
 	}()
 
 	err = <-shutdownCh

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1160,6 +1160,9 @@ func quitquitquit(quitOnce *sync.Once, shutdownCh chan<- error) http.HandlerFunc
 		quitOnce.Do(func() {
 			select {
 			case shutdownCh <- errQuitQuitQuit:
+				cmd.logger.Debugf("QuitQuitQuit signal received. Writing to shutdown channel.")
+			case <-shutdownCh:
+				cmd.logger.Debugf("Could not write to shutdown channel. The proxy is already exiting.")
 			default:
 				// The write attempt to shutdownCh failed and
 				// the proxy is already exiting.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1134,9 +1134,9 @@ func runSignalWrapper(cmd *Command) (err error) {
 		)
 	}
 
-	go func() { 
+	go func() {
 		cmd.logger.Debugf("Starting to listen on shutdown channel.")
-		shutdownCh <- p.Serve(ctx, notifyStarted) 
+		shutdownCh <- p.Serve(ctx, notifyStarted)
 	}()
 
 	err = <-shutdownCh
@@ -1164,11 +1164,9 @@ func quitquitquit(quitOnce *sync.Once, shutdownCh chan<- error) http.HandlerFunc
 		quitOnce.Do(func() {
 			select {
 			case shutdownCh <- errQuitQuitQuit:
-				cmd.logger.Debugf("QuitQuitQuit signal received. Writing to shutdown channel.")
 			default:
 				// The write attempt to shutdownCh failed and
 				// the proxy is already exiting.
-				cmd.logger.Debugf("Could not write to shutdown channel. The proxy is already exiting.")
 			}
 		})
 	}
@@ -1186,7 +1184,6 @@ func startHTTPServer(ctx context.Context, l cloudsql.Logger, addr string, mux *h
 			return
 		}
 		if err != nil {
-			cmd.logger.Debugf("Error starting HTTP server. Writing error to shutdown channel.")
 			shutdownCh <- fmt.Errorf("failed to start HTTP server: %v", err)
 		}
 	}()

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1165,8 +1165,6 @@ func quitquitquit(quitOnce *sync.Once, shutdownCh chan<- error) http.HandlerFunc
 			select {
 			case shutdownCh <- errQuitQuitQuit:
 				cmd.logger.Debugf("QuitQuitQuit signal received. Writing to shutdown channel.")
-			case <-shutdownCh:
-				cmd.logger.Debugf("Could not write to shutdown channel. The proxy is already exiting.")
 			default:
 				// The write attempt to shutdownCh failed and
 				// the proxy is already exiting.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1007,8 +1007,10 @@ func runSignalWrapper(cmd *Command) (err error) {
 		}
 		switch s {
 		case syscall.SIGINT:
+			cmd.logger.Debugf("Sending SIGINT signal for proxy to shutdown.")
 			shutdownCh <- errSigInt
 		case syscall.SIGTERM:
+			cmd.logger.Debugf("Sending SIGTERM signal for proxy to shutdown.")
 			if cmd.conf.ExitZeroOnSigterm {
 				shutdownCh <- errSigTermZero
 			} else {


### PR DESCRIPTION
Add additional debug log entries around `shutdownCh` to allow for verification that SIGINT/SIGTERM signals are being properly sent.