### PR TITLE
docs: Fix link to code of conduct in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -675,7 +675,7 @@ By participating in this project you agree to abide by its terms. See
 [ci-build]: https://github.com/GoogleCloudPlatform/cloudsql-proxy/actions/workflows/tests.yaml?query=event%3Apush+branch%3Amain
 [cloud-sql]: https://cloud.google.com/sql
 [code-samples]: https://cloud.google.com/sql/docs/mysql/samples
-[code-of-conduct]: CONTRIBUTING.md#contributor-code-of-conduct
+[code-of-conduct]: CODE_OF_CONDUCT.md
 [connect-to-k8s]: https://cloud.google.com/sql/docs/mysql/connect-kubernetes-engine
 [connection-overview]: https://cloud.google.com/sql/docs/mysql/connect-overview
 [contributing]: CONTRIBUTING.md


### PR DESCRIPTION
[CONTRIBUTING.md](https://github.com/GoogleCloudPlatform/cloud-sql-proxy/blob/939e21b035c41faa452a5737f83223bf8fcc7233/CONTRIBUTING.md) has no `contributor-code-of-conduct` header. 

I think [CODE_OF_CONDUCT.md](https://github.com/GoogleCloudPlatform/cloud-sql-proxy/blob/main/CODE_OF_CONDUCT.md) is the best destination for this link (that file was added by a google bot that didn't update the readme). It's also possible that this should link to the `review-our-community-guidelines` header in `CONTRIBUTING.md`. I'm happy to update this PR to do that if that's the case.