### PR TITLE
docs: update documentation of accepted /quitquitquit HTTP methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -556,7 +556,7 @@ See the [documentation on pprof][pprof] for details on how to use the
 profiler.
 
 When --quitquitquit is set, the admin server adds an endpoint at
-/quitquitquit. The admin server exits gracefully when it receives a POST
+/quitquitquit. The admin server exits gracefully when it receives a GET or POST
 request at /quitquitquit.
 
 [pprof]: https://pkg.go.dev/net/http/pprof.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -288,7 +288,7 @@ Localhost Admin Server
   profiler at https://pkg.go.dev/net/http/pprof.
 
   When --quitquitquit is set, the admin server adds an endpoint at
-  /quitquitquit. The admin server exits gracefully when it receives a POST
+  /quitquitquit. The admin server exits gracefully when it receives a GET or POST
   request at /quitquitquit.
 
 Debug logging

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -250,7 +250,7 @@ type Config struct {
 	// Debug enables a debug handler on localhost.
 	Debug bool
 	// QuitQuitQuit enables a handler that will shut the Proxy down upon
-	// receiving a POST request.
+	// receiving a GET or POST request.
 	QuitQuitQuit bool
 	// DebugLogs enables debug level logging.
 	DebugLogs bool


### PR DESCRIPTION
In version 2.7.0, the `/quitquitquit` endpoint was updated to accept GET requests (in addition to POST requests, which it already accepted). See [changelog](https://github.com/GoogleCloudPlatform/cloud-sql-proxy/blob/main/CHANGELOG.md#270-2023-09-19). Also see the PR that made this change, https://github.com/GoogleCloudPlatform/cloud-sql-proxy/pull/1947.

Recently, while debugging a k8s shutdown problem, I quickly skimmed the readme to check that I was using `/quitquitquit` correctly and became convinced that I wasn't because I was sending a GET request. I had copied the example here, but didn't remember that in the moment:

https://github.com/GoogleCloudPlatform/cloud-sql-proxy/blob/848e1ea79287ac4772d603ff6391d0fcd8483cb5/examples/k8s-health-check/proxy_with_http_health_check.yaml#L107-L115

Updating the docs to be more complete on this topic.