### PR TITLE
feat: add support for Debian bookworm

### DIFF
--- a/Dockerfile.bookworm
+++ b/Dockerfile.bookworm
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,10 +23,10 @@ ARG TARGETARCH
 
 RUN go get ./...
 RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
-    go build -ldflags "-X github.com/GoogleCloudPlatform/cloud-sql-proxy/v2/cmd.metadataString=container.buster"
+    go build -ldflags "-X github.com/GoogleCloudPlatform/cloud-sql-proxy/v2/cmd.metadataString=container.bookworm"
 
 # Final stage
-FROM gcr.io/cloud-marketplace-containers/google/debian10@sha256:bf5274d185680301f076431113bb7f7e21c7748dec0e066166d4bd02a8ff1c09
+FROM gcr.io/cloud-marketplace-containers/google/debian12@sha256:9df4cf8df3a3466796d76692ddda1fdcbe5018a2810d332c9a99e2ee2325b6cf
 
 LABEL org.opencontainers.image.source="https://github.com/GoogleCloudPlatform/cloud-sql-proxy"
 

--- a/README.md
+++ b/README.md
@@ -404,7 +404,7 @@ currently supported:
 
 - `$VERSION` (default)
 - `$VERSION-alpine`
-- `$VERSION-buster`
+- `$VERSION-bookworm`
 - `$VERSION-bullseye`
 
 <!-- {x-release-please-start-version} -->
@@ -423,7 +423,7 @@ We recommend pinning to a specific version tag and using automation with a CI pi
 to update regularly.
 
 The default container image uses [distroless][] with a non-root user. If you
-need a shell or related tools, use the Alpine or Buster images listed above.
+need a shell or related tools, use the Alpine or Bookworm images listed above.
 
 [distroless]: https://github.com/GoogleContainerTools/distroless
 


### PR DESCRIPTION
Add support for Debian 12 `"bookworm"` and remove support for
Debian 10 `"buster"` as its LTS ended on June 30 ([debian wiki](https://wiki.debian.org/LTS)).

Using Debian build from Cloud Marketplace: [gcr.io/cloud-marketplace-containers/google/debian12](gcr.io/cloud-marketplace-containers/google/debian12)

This will require internal changes to our release script as well.

Fixes #2072 