### PR TITLE
chore: correct address in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,10 +434,9 @@ The containers have the proxy as an `ENTRYPOINT` so, to use the proxy from a
 container, all you need to do is specify options using the command, and expose
 the proxy's internal port to the host. For example, you can use:
 
-<!-- {x-release-please-start-version} -->
 ```shell
 docker run --publish <host-port>:<proxy-port> \
-    gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.12.0 \
+    gcr.io/cloud-sql-connectors/cloud-sql-proxy:latest \
     --address "0.0.0.0" --port <proxy-port> <instance-connection-name>
 ```
 
@@ -465,12 +464,11 @@ For example, a full command using a JSON credentials file might look like
 docker run \
     --publish <host-port>:<proxy-port> \
     --mount type=bind,source="$(pwd)"/sa.json,target=/config/sa.json \
-    gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.12.0 \
+    gcr.io/cloud-sql-connectors/cloud-sql-proxy:latest \
     --address 0.0.0.0 \
     --port <proxy-port> \
     --credentials-file /config/sa.json <instance-connection-name>
 ```
-<!-- {x-release-please-end} -->
 
 ## Running as a Kubernetes Sidecar
 

--- a/README.md
+++ b/README.md
@@ -438,10 +438,10 @@ the proxy's internal port to the host. For example, you can use:
 ```shell
 docker run --publish <host-port>:<proxy-port> \
     gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.12.0 \
-    --address "2.12.0.0" --port <proxy-port> <instance-connection-name>
+    --address "0.0.0.0" --port <proxy-port> <instance-connection-name>
 ```
 
-You'll need the `--address "2.12.0.0"` so that the proxy doesn't only listen for
+You'll need the `--address "0.0.0.0"` so that the proxy doesn't only listen for
 connections originating from *within* the container.
 
 You will need to authenticate using one of the methods outlined in the
@@ -466,7 +466,7 @@ docker run \
     --publish <host-port>:<proxy-port> \
     --mount type=bind,source="$(pwd)"/sa.json,target=/config/sa.json \
     gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.12.0 \
-    --address 2.12.0.0 \
+    --address 0.0.0.0 \
     --port <proxy-port> \
     --credentials-file /config/sa.json <instance-connection-name>
 ```


### PR DESCRIPTION
Undoing the release-please changes that updated the `0.0.0.0` address to the Proxy version.