### PR TITLE
chore: don't overwrite builtin max function

### DIFF
--- a/cmd/options.go
+++ b/cmd/options.go
@@ -52,9 +52,9 @@ func WithFuseTempDir(dir string) Option {
 
 // WithMaxConnections sets the maximum allowed number of connections. Default
 // is no limit.
-func WithMaxConnections(max uint64) Option {
+func WithMaxConnections(mc uint64) Option {
 	return func(c *Command) {
-		c.conf.MaxConnections = max
+		c.conf.MaxConnections = mc
 	}
 }
 

--- a/internal/healthcheck/healthcheck.go
+++ b/internal/healthcheck/healthcheck.go
@@ -97,8 +97,8 @@ func (c *Check) HandleReadiness(w http.ResponseWriter, _ *http.Request) {
 	default:
 	}
 
-	if open, max := c.proxy.ConnCount(); max > 0 && open == max {
-		err := fmt.Errorf("max connections reached (open = %v, max = %v)", open, max)
+	if open, maxCount := c.proxy.ConnCount(); maxCount > 0 && open == maxCount {
+		err := fmt.Errorf("max connections reached (open = %v, max = %v)", open, maxCount)
 		c.logger.Errorf("[Health Check] Readiness failed: %v", err)
 		w.WriteHeader(http.StatusServiceUnavailable)
 		w.Write([]byte(err.Error()))


### PR DESCRIPTION
Rename `max` vars. 

New `golangci-lint` check now does not allow variable names to be `max` or `min` due to built-ins.