### PR TITLE
chore: Update code to eliminate new golangci-lint errors 

### DIFF
--- a/internal/proxy/fuse_darwin.go
+++ b/internal/proxy/fuse_darwin.go
@@ -34,7 +34,7 @@ func SupportsFUSE() error {
 	if _, err := os.Stat(macfusePath); err != nil {
 		// if that fails, check for osxfuse next
 		if _, err := os.Stat(osxfusePath); err != nil {
-			return errors.New("failed to find osxfuse or macfuse: verify FUSE installation and try again (see https://osxfuse.github.io).")
+			return errors.New("failed to find osxfuse or macfuse: verify FUSE installation and try again (see https://osxfuse.github.io)")
 		}
 	}
 	return nil

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -52,13 +52,13 @@ func (f *fakeDialer) dialAttempts() int {
 	return f.dialCount
 }
 
-func (f *fakeDialer) engineVersionAttempts() int {
+func (f *fakeDialer) engineVersionAttempts() int { //nolint:unused
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return f.engineVersionCount
 }
 
-func (f *fakeDialer) dialedInstances() []string {
+func (f *fakeDialer) dialedInstances() []string { //nolint:unused
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return append([]string{}, f.instances...)


### PR DESCRIPTION
This fixes new golangci-lint errors first found in golangci-lint@v1.62