### PR TITLE
chore: bump examples to latest Proxy and showcase IAM AuthN

### DIFF
--- a/examples/k8s-sidecar/job_with_shutdown_hook.yaml
+++ b/examples/k8s-sidecar/job_with_shutdown_hook.yaml
@@ -40,43 +40,43 @@ spec:
         app: busybox
     spec:
       containers:
-      - name: my-application
-        # Run your batch job command.
-        # Then, send a HTTTP POST request to the proxy sidecar container's
-        # /quitquitquit api. This will cause the proxy process to exit.
-        command:
-        - sh
-        - -c
-        - >
-          my_batch_job --host=127.0.0.1 --port=<DB_PORT> --username=<DB_USER> --dbname=<DB_NAME>
-          curl http://localhost:9091/quitquitquit
-        image: busybox
-        imagePullPolicy: IfNotPresent
-        resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
-      - name: cloud-sql-proxy
-        # It is recommended to use the latest version of the Cloud SQL Auth Proxy
-        # Make sure to update on a regular schedule!
-        image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.11.4
-        args:
-        # Enable the admin api server on port 9091
-        - "--admin-port=9091"
-        # Enable the /quitquitquit admin api endpoint
-        - "--quitquitquit"
+        - name: my-application
+          # Run your batch job command.
+          # Then, send a HTTTP POST request to the proxy sidecar container's
+          # /quitquitquit api. This will cause the proxy process to exit.
+          command:
+            - sh
+            - -c
+            - >
+              my_batch_job --host=127.0.0.1 --port=<DB_PORT> --username=<DB_USER> --dbname=<DB_NAME>
+              curl http://localhost:9091/quitquitquit
+          image: busybox
+          imagePullPolicy: IfNotPresent
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+        - name: cloud-sql-proxy
+          # It is recommended to use the latest version of the Cloud SQL Auth Proxy
+          # Make sure to update on a regular schedule!
+          image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.14.1
+          args:
+            # Enable the admin api server on port 9091
+            - "--admin-port=9091"
+            # Enable the /quitquitquit admin api endpoint
+            - "--quitquitquit"
 
-        # Tell the proxy to exit gracefully if it receives a SIGTERM
-        - "--exit-zero-on-sigterm"
+            # Tell the proxy to exit gracefully if it receives a SIGTERM
+            - "--exit-zero-on-sigterm"
 
-        # Replace DB_PORT with the port the proxy should listen on
-        - "--port=<DB_PORT>"
-        - "<INSTANCE_CONNECTION_NAME>"
+            # Replace DB_PORT with the port the proxy should listen on
+            - "--port=<DB_PORT>"
+            - "<INSTANCE_CONNECTION_NAME>"
 
-        securityContext:
-          runAsNonRoot: true
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu:    "1"
+          securityContext:
+            runAsNonRoot: true
+          resources:
+            requests:
+              memory: "2Gi"
+              cpu: "1"
       restartPolicy: Never
       terminationGracePeriodSeconds: 30

--- a/examples/k8s-sidecar/proxy_with_sa_key.yaml
+++ b/examples/k8s-sidecar/proxy_with_sa_key.yaml
@@ -26,69 +26,72 @@ spec:
         app: <YOUR-APPLICATION-NAME>
     spec:
       containers:
-      - name: <YOUR-APPLICATION-NAME>
-        # ... other container configuration
-        env:
-        - name: DB_USER
-          valueFrom:
-            secretKeyRef:
-              name: <YOUR-DB-SECRET>
-              key: username
-        - name: DB_PASS
-          valueFrom:
-            secretKeyRef:
-              name: <YOUR-DB-SECRET>
-              key: password
-        - name: DB_NAME
-          valueFrom:
-            secretKeyRef:
-              name: <YOUR-DB-SECRET>
-              key: database
-      - name: cloud-sql-proxy
-        # It is recommended to use the latest version of the Cloud SQL Auth Proxy
-        # Make sure to update on a regular schedule!
-        image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.11.4
-        args:
-          # If connecting from a VPC-native GKE cluster, you can use the
-          # following flag to have the proxy connect over private IP
-          # - "--private-ip"
+        - name: <YOUR-APPLICATION-NAME>
+          # ... other container configuration
+          env:
+            - name: DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: <YOUR-DB-SECRET>
+                  key: username
+            - name: DB_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: <YOUR-DB-SECRET>
+                  key: password
+            - name: DB_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: <YOUR-DB-SECRET>
+                  key: database
+        - name: cloud-sql-proxy
+          # It is recommended to use the latest version of the Cloud SQL Auth Proxy
+          # Make sure to update on a regular schedule!
+          image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.14.1
+          args:
+            # If connecting from a VPC-native GKE cluster, you can use the
+            # following flag to have the proxy connect over private IP
+            # - "--private-ip"
 
-          # Enable structured logging with LogEntry format:
-          - "--structured-logs"
+            # If you are not connecting with Automatic IAM AuthN, you can delete
+            # the following flag.
+            - "--auto-iam-authn"
 
+            # Enable structured logging with LogEntry format:
+            - "--structured-logs"
 
-          # Replace DB_PORT with the port the proxy should listen on
-          - "--port=<DB_PORT>"
-          - "<INSTANCE_CONNECTION_NAME>"
+            # Replace DB_PORT with the port the proxy should listen on
+            - "--port=<DB_PORT>"
+            - "<INSTANCE_CONNECTION_NAME>"
 
-        # [START cloud_sql_proxy_k8s_volume_mount]
-          # This flag specifies where the service account key can be found
-          - "--credentials-file=/secrets/service_account.json"
-        securityContext:
-          # The default Cloud SQL Auth Proxy image runs as the
-          # "nonroot" user and group (uid: 65532) by default.
-          runAsNonRoot: true
-        volumeMounts:
-        - name: <YOUR-SA-SECRET-VOLUME>
-          mountPath: /secrets/
-          readOnly: true
-          # [END cloud_sql_proxy_k8s_volume_mount]
-        # Resource configuration depends on an application's requirements. You
-        # should adjust the following values based on what your application
-        # needs. For details, see https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-        resources:
-          requests:
-            # The proxy's memory use scales linearly with the number of active
-            # connections. Fewer open connections will use less memory. Adjust
-            # this value based on your application's requirements.
-            memory: "2Gi"
-            # The proxy's CPU use scales linearly with the amount of IO between
-            # the database and the application. Adjust this value based on your
-            # application's requirements.
-            cpu:    "1"
+            # [START cloud_sql_proxy_k8s_volume_mount]
+            # This flag specifies where the service account key can be found
+            - "--credentials-file=/secrets/service_account.json"
+          securityContext:
+            # The default Cloud SQL Auth Proxy image runs as the
+            # "nonroot" user and group (uid: 65532) by default.
+            runAsNonRoot: true
+          volumeMounts:
+            - name: <YOUR-SA-SECRET-VOLUME>
+              mountPath: /secrets/
+              readOnly: true
+              # [END cloud_sql_proxy_k8s_volume_mount]
+          # Resource configuration depends on an application's requirements. You
+          # should adjust the following values based on what your application
+          # needs. For details, see https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+          resources:
+            requests:
+              # The proxy's memory use scales linearly with the number of active
+              # connections. Fewer open connections will use less memory. Adjust
+              # this value based on your application's requirements.
+              memory: "2Gi"
+              # The proxy's CPU use scales linearly with the amount of IO between
+              # the database and the application. Adjust this value based on your
+              # application's requirements.
+              cpu: "1"
       # [START cloud_sql_proxy_k8s_volume_secret]
       volumes:
-      - name: <YOUR-SA-SECRET-VOLUME>
-        secret:
-          secretName: <YOUR-SA-SECRET>
+        - name: <YOUR-SA-SECRET-VOLUME>
+          secret:
+            secretName: <YOUR-SA-SECRET>
       # [END cloud_sql_proxy_k8s_volume_secret]

--- a/examples/k8s-sidecar/proxy_with_workload_identity.yaml
+++ b/examples/k8s-sidecar/proxy_with_workload_identity.yaml
@@ -30,59 +30,63 @@ spec:
       # [END cloud_sql_proxy_k8s_sa]
       # [START cloud_sql_proxy_k8s_secrets]
       containers:
-      - name: <YOUR-APPLICATION-NAME>
-        # ... other container configuration
-        env:
-        - name: DB_USER
-          valueFrom:
-            secretKeyRef:
-              name: <YOUR-DB-SECRET>
-              key: username
-        - name: DB_PASS
-          valueFrom:
-            secretKeyRef:
-              name: <YOUR-DB-SECRET>
-              key: password
-        - name: DB_NAME
-          valueFrom:
-            secretKeyRef:
-              name: <YOUR-DB-SECRET>
-              key: database
-      # [END cloud_sql_proxy_k8s_secrets]
-      # [START cloud_sql_proxy_k8s_container]
-      - name: cloud-sql-proxy
-        # It is recommended to use the latest version of the Cloud SQL Auth Proxy
-        # Make sure to update on a regular schedule!
-        image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.11.4
-        args:
-          # If connecting from a VPC-native GKE cluster, you can use the
-          # following flag to have the proxy connect over private IP
-          # - "--private-ip"
+        - name: <YOUR-APPLICATION-NAME>
+          # ... other container configuration
+          env:
+            - name: DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: <YOUR-DB-SECRET>
+                  key: username
+            - name: DB_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: <YOUR-DB-SECRET>
+                  key: password
+            - name: DB_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: <YOUR-DB-SECRET>
+                  key: database
+        # [END cloud_sql_proxy_k8s_secrets]
+        # [START cloud_sql_proxy_k8s_container]
+        - name: cloud-sql-proxy
+          # It is recommended to use the latest version of the Cloud SQL Auth Proxy
+          # Make sure to update on a regular schedule!
+          image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.14.1
+          args:
+            # If connecting from a VPC-native GKE cluster, you can use the
+            # following flag to have the proxy connect over private IP
+            # - "--private-ip"
 
-          # Enable structured logging with LogEntry format:
-          - "--structured-logs"
+            # If you are not connecting with Automatic IAM, you can delete
+            # the following flag.
+            - "--auto-iam-authn"
 
-          # Replace DB_PORT with the port the proxy should listen on
-          - "--port=<DB_PORT>"
-          - "<INSTANCE_CONNECTION_NAME>"
-        
-        securityContext:
-          # The default Cloud SQL Auth Proxy image runs as the
-          # "nonroot" user and group (uid: 65532) by default.
-          runAsNonRoot: true
-        # You should use resource requests/limits as a best practice to prevent
-        # pods from consuming too many resources and affecting the execution of
-        # other pods. You should adjust the following values based on what your
-        # application needs. For details, see
-        # https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-        resources:
-          requests:
-            # The proxy's memory use scales linearly with the number of active
-            # connections. Fewer open connections will use less memory. Adjust
-            # this value based on your application's requirements.
-            memory: "2Gi"
-            # The proxy's CPU use scales linearly with the amount of IO between
-            # the database and the application. Adjust this value based on your
-            # application's requirements.
-            cpu:    "1"
+            # Enable structured logging with LogEntry format:
+            - "--structured-logs"
+
+            # Replace DB_PORT with the port the proxy should listen on
+            - "--port=<DB_PORT>"
+            - "<INSTANCE_CONNECTION_NAME>"
+
+          securityContext:
+            # The default Cloud SQL Auth Proxy image runs as the
+            # "nonroot" user and group (uid: 65532) by default.
+            runAsNonRoot: true
+          # You should use resource requests/limits as a best practice to prevent
+          # pods from consuming too many resources and affecting the execution of
+          # other pods. You should adjust the following values based on what your
+          # application needs. For details, see
+          # https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+          resources:
+            requests:
+              # The proxy's memory use scales linearly with the number of active
+              # connections. Fewer open connections will use less memory. Adjust
+              # this value based on your application's requirements.
+              memory: "2Gi"
+              # The proxy's CPU use scales linearly with the amount of IO between
+              # the database and the application. Adjust this value based on your
+              # application's requirements.
+              cpu: "1"
       # [END cloud_sql_proxy_k8s_container]


### PR DESCRIPTION
Small updates to examples:
- Bumping k8s examples to latest proxy version `v2.14.1`.
- Enabling IAM AuthN by default in examples, this is what we showcase in our [samples repos](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/cloud-sql/postgres/sqlalchemy/deployment.yaml#L83) so aligning docs
- Lint YAML files
