### PR TITLE
chore: have release-please update generated docs

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -25,6 +25,7 @@ branches:
 extraFiles:
   - README.md
   - cmd/root.go
+  - docs/cmd/cloud-sql-proxy.md
   - examples/k8s-health-check/README.md
   - examples/k8s-service/README.md
   - examples/k8s-sidecar/README.md


### PR DESCRIPTION
This commit ensures we don't need to manually update the version in the generated docs.