### PR TITLE
chore: remove Go toolchain from v1 Proxy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/GoogleCloudPlatform/cloudsql-proxy
 
 go 1.23.0
 
-toolchain go1.23.3
-
 require (
 	cloud.google.com/go/compute/metadata v0.6.0
 	github.com/coreos/go-systemd/v22 v22.5.0


### PR DESCRIPTION
No need for toolchain in Go 1.23