### PR TITLE
chore: update v1 Proxy to use Go 1.24

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.23"
+          go-version: "1.24"
 
       - name: Checkout base branch
         uses: actions/checkout@v3

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.23"
+          go-version: "1.24"
       - name: Install goimports
         run: go install golang.org/x/tools/cmd/goimports@latest
       - name: Checkout code

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -29,7 +29,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        go-version: ["1.22", "1.23"]
+        go-version: ["1.23", "1.24"]
       fail-fast: false
     permissions:
       contents: "read"
@@ -125,7 +125,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.23"
+          go-version: "1.24"
 
       - id: "auth"
         name: "Authenticate to Google Cloud"

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/GoogleCloudPlatform/cloudsql-proxy
 
-go 1.23.0
-
-toolchain go1.23.3
+go 1.24
 
 require (
 	cloud.google.com/go/compute/metadata v0.6.0


### PR DESCRIPTION
Go 1.24 was released, see https://go.dev/doc/go1.24.

Related to #2387 