### PR TITLE
Add note about the new executable name

### DIFF
--- a/migration-guide.md
+++ b/migration-guide.md
@@ -34,9 +34,25 @@ and then attempt to use a private IP. In v2, the Proxy now defaults to public
 IP without trying private IP. If you want to use private IP, you must pass
 either the `--private-ip` flag or the query parameter. See the README for details.
 
-In some cases, the v1 behavior may be preferrable. Use the `--auto-ip` flag to
+In some cases, the v1 behavior may be preferable. Use the `--auto-ip` flag to
 mimic v1 behavior. We generally recommend using deterministic IP address selection,
 but recognize in some legacy environments `--auto-ip` may be necessary.
+
+## Executable Name Change
+
+Note that the name of the executable has changed, using hyphens rather than underscores:
+
+```
+# v1
+./cloud_sql_proxy
+```
+
+vs
+
+```
+# v2
+./cloud-sql-proxy
+```
 
 ## Sample Invocations
 


### PR DESCRIPTION
It is a subtle difference to notice in all the examples that the executable name has changed from using underscores to hyphens. It would be helpful to the reader to have this explicitly pointed out, the same way that the other changes have been spelled out.

(Yes, it is obvious and self-evident when you are typing the old/new command on the command line that `cloud_sql_proxy` does not exist. But I lost a good bit time pinpointing this problem when it was inside a k8s container that had been converted from v1 to v2, even when I got all the new flag changes correct! 😀)