### PR TITLE
test: add MySQL MCP tests

### DIFF
--- a/.ci/cloudbuild.yaml
+++ b/.ci/cloudbuild.yaml
@@ -28,6 +28,8 @@ steps:
         "MYSQL_USER",
         "MYSQL_PASS",
         "MYSQL_DB",
+        "MYSQL_MCP_CONNECTION_NAME",
+        "MYSQL_MCP_PASS",
         "POSTGRES_CONNECTION_NAME",
         "POSTGRES_USER",
         "POSTGRES_USER_IAM",
@@ -64,6 +66,10 @@ availableSecrets:
       env: "MYSQL_PASS"
     - versionName: "projects/$PROJECT_ID/secrets/MYSQL_DB/versions/latest"
       env: "MYSQL_DB"
+    - versionName: "projects/$PROJECT_ID/secrets/MYSQL_MCP_CONNECTION_NAME/versions/latest"
+      env: "MYSQL_MCP_CONNECTION_NAME"
+    - versionName: "projects/$PROJECT_ID/secrets/MYSQL_MCP_PASS/versions/latest"
+      env: "MYSQL_MCP_PASS"
     - versionName: "projects/$PROJECT_ID/secrets/POSTGRES_CONNECTION_NAME/versions/latest"
       env: "POSTGRES_CONNECTION_NAME"
     - versionName: "projects/$PROJECT_ID/secrets/POSTGRES_USER/versions/latest"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -87,6 +87,8 @@ jobs:
             MYSQL_USER:${{ vars.GOOGLE_CLOUD_PROJECT }}/MYSQL_USER
             MYSQL_PASS:${{ vars.GOOGLE_CLOUD_PROJECT }}/MYSQL_PASS
             MYSQL_DB:${{ vars.GOOGLE_CLOUD_PROJECT }}/MYSQL_DB
+            MYSQL_MCP_CONNECTION_NAME:${{ vars.GOOGLE_CLOUD_PROJECT }}/MYSQL_MCP_CONNECTION_NAME
+            MYSQL_MCP_PASS:${{ vars.GOOGLE_CLOUD_PROJECT }}/MYSQL_MCP_PASS
             POSTGRES_CONNECTION_NAME:${{ vars.GOOGLE_CLOUD_PROJECT }}/POSTGRES_CONNECTION_NAME
             POSTGRES_USER:${{ vars.GOOGLE_CLOUD_PROJECT }}/POSTGRES_USER
             POSTGRES_USER_IAM:${{ vars.GOOGLE_CLOUD_PROJECT }}/POSTGRES_USER_IAM
@@ -115,6 +117,8 @@ jobs:
           MYSQL_USER: "${{ steps.secrets.outputs.MYSQL_USER }}"
           MYSQL_PASS: "${{ steps.secrets.outputs.MYSQL_PASS }}"
           MYSQL_DB: "${{ steps.secrets.outputs.MYSQL_DB }}"
+          MYSQL_MCP_CONNECTION_NAME: "${{ steps.secrets.outputs.MYSQL_MCP_CONNECTION_NAME }}"
+          MYSQL_MCP_PASS: "${{ steps.secrets.outputs.MYSQL_MCP_PASS }}"
           POSTGRES_CONNECTION_NAME: "${{ steps.secrets.outputs.POSTGRES_CONNECTION_NAME }}"
           POSTGRES_USER: "${{ steps.secrets.outputs.POSTGRES_USER }}"
           POSTGRES_USER_IAM: "${{ steps.secrets.outputs.POSTGRES_USER_IAM }}"

--- a/tests/mysql_test.go
+++ b/tests/mysql_test.go
@@ -25,13 +25,13 @@ import (
 )
 
 var (
-	mysqlConnName 		= flag.String("mysql_conn_name", os.Getenv("MYSQL_CONNECTION_NAME"), "Cloud SQL MYSQL instance connection name, in the form of 'project:region:instance'.")
-	mysqlUser     		= flag.String("mysql_user", os.Getenv("MYSQL_USER"), "Name of database user.")
-	mysqlPass     		= flag.String("mysql_pass", os.Getenv("MYSQL_PASS"), "Password for the database user; be careful when entering a password on the command line (it may go into your terminal's history).")
-	mysqlDB       		= flag.String("mysql_db", os.Getenv("MYSQL_DB"), "Name of the database to connect to.")
-	mysqlMCPConnName 	= flag.String("mysql_mcp_conn_name", os.Getenv("MYSQL_MCP_CONNECTION_NAME"), "Cloud SQL MCP MYSQL instance connection name, in the form of 'project:region:instance'.")
-	mysqlMCPPass     	= flag.String("mysql_mcp_pass", os.Getenv("MYSQL_MCP_PASS"), "Password for the database user; be careful when entering a password on the command line (it may go into your terminal's history).")
-	ipType        		= flag.String("ip_type", func() string {
+	mysqlConnName    = flag.String("mysql_conn_name", os.Getenv("MYSQL_CONNECTION_NAME"), "Cloud SQL MYSQL instance connection name, in the form of 'project:region:instance'.")
+	mysqlUser        = flag.String("mysql_user", os.Getenv("MYSQL_USER"), "Name of database user.")
+	mysqlPass        = flag.String("mysql_pass", os.Getenv("MYSQL_PASS"), "Password for the database user; be careful when entering a password on the command line (it may go into your terminal's history).")
+	mysqlDB          = flag.String("mysql_db", os.Getenv("MYSQL_DB"), "Name of the database to connect to.")
+	mysqlMCPConnName = flag.String("mysql_mcp_conn_name", os.Getenv("MYSQL_MCP_CONNECTION_NAME"), "Cloud SQL MCP MYSQL instance connection name, in the form of 'project:region:instance'.")
+	mysqlMCPPass     = flag.String("mysql_mcp_pass", os.Getenv("MYSQL_MCP_PASS"), "Password for the database user; be careful when entering a password on the command line (it may go into your terminal's history).")
+	ipType           = flag.String("ip_type", func() string {
 		if v := os.Getenv("IP_TYPE"); v != "" {
 			return v
 		}

--- a/tests/mysql_test.go
+++ b/tests/mysql_test.go
@@ -25,11 +25,13 @@ import (
 )
 
 var (
-	mysqlConnName = flag.String("mysql_conn_name", os.Getenv("MYSQL_CONNECTION_NAME"), "Cloud SQL MYSQL instance connection name, in the form of 'project:region:instance'.")
-	mysqlUser     = flag.String("mysql_user", os.Getenv("MYSQL_USER"), "Name of database user.")
-	mysqlPass     = flag.String("mysql_pass", os.Getenv("MYSQL_PASS"), "Password for the database user; be careful when entering a password on the command line (it may go into your terminal's history).")
-	mysqlDB       = flag.String("mysql_db", os.Getenv("MYSQL_DB"), "Name of the database to connect to.")
-	ipType        = flag.String("ip_type", func() string {
+	mysqlConnName 		= flag.String("mysql_conn_name", os.Getenv("MYSQL_CONNECTION_NAME"), "Cloud SQL MYSQL instance connection name, in the form of 'project:region:instance'.")
+	mysqlUser     		= flag.String("mysql_user", os.Getenv("MYSQL_USER"), "Name of database user.")
+	mysqlPass     		= flag.String("mysql_pass", os.Getenv("MYSQL_PASS"), "Password for the database user; be careful when entering a password on the command line (it may go into your terminal's history).")
+	mysqlDB       		= flag.String("mysql_db", os.Getenv("MYSQL_DB"), "Name of the database to connect to.")
+	mysqlMCPConnName 	= flag.String("mysql_mcp_conn_name", os.Getenv("MYSQL_MCP_CONNECTION_NAME"), "Cloud SQL MCP MYSQL instance connection name, in the form of 'project:region:instance'.")
+	mysqlMCPPass     	= flag.String("mysql_mcp_pass", os.Getenv("MYSQL_MCP_PASS"), "Password for the database user; be careful when entering a password on the command line (it may go into your terminal's history).")
+	ipType        		= flag.String("ip_type", func() string {
 		if v := os.Getenv("IP_TYPE"); v != "" {
 			return v
 		}
@@ -47,6 +49,10 @@ func requireMySQLVars(t *testing.T) {
 		t.Fatal("'mysql_pass' not set")
 	case *mysqlDB:
 		t.Fatal("'mysql_db' not set")
+	case *mysqlMCPConnName:
+		t.Fatal("'mysql_mcp_conn_name' not set")
+	case *mysqlMCPPass:
+		t.Fatal("'mysql_mcp_pass' not set")
 	}
 }
 
@@ -107,6 +113,32 @@ func TestMySQLUnix(t *testing.T) {
 	}
 	// Prepare the initial arguments
 	args := []string{"--unix-socket", tmpDir, *mysqlConnName}
+	// Add the IP type flag using the helper
+	args = AddIPTypeFlag(args)
+	// Run the test
+	proxyConnTest(t, args, "mysql", cfg.FormatDSN())
+}
+
+func TestMySQLMCPUnix(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping MySQL integration tests")
+	}
+	requireMySQLVars(t)
+	tmpDir, cleanup := createTempDir(t)
+	defer cleanup()
+
+	cfg := mysql.Config{
+		User:                 *mysqlUser,
+		Passwd:               *mysqlMCPPass,
+		DBName:               *mysqlDB,
+		AllowNativePasswords: true,
+		// re-use utility function to determine the Unix address in a
+		// Windows-friendly way.
+		Addr: proxy.UnixAddress(tmpDir, *mysqlMCPConnName),
+		Net:  "unix",
+	}
+	// Prepare the initial arguments
+	args := []string{"--unix-socket", tmpDir, *mysqlMCPConnName}
 	// Add the IP type flag using the helper
 	args = AddIPTypeFlag(args)
 	// Run the test


### PR DESCRIPTION
Add integration tests for MySQL for Cloud SQL's [Managed Connection Pooling](https://cloud.google.com/sql/docs/mysql/managed-connection-pooling) (MCP)

Reference: https://github.com/GoogleCloudPlatform/cloud-sql-python-connector/pull/1267