### PR TITLE
feat: add flag for ignoring bad connections

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -527,6 +527,9 @@ CPU may be throttled and a background refresh cannot run reliably
 against all specified instances. If an instance is unreachable, the Proxy exits with a failure
 status code.`)
 
+	localFlags.BoolVar(&c.conf.IgnoreFailedConnections, "ignore-failed-connections", false,
+		`If set, the Proxy will not exit on startup when Cloud SQL instances are unreachable.`)
+
 	// Global and per instance flags
 	localFlags.StringVarP(&c.conf.Addr, "address", "a", "127.0.0.1",
 		"(*) Address to bind Cloud SQL instance listeners.")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -527,8 +527,9 @@ CPU may be throttled and a background refresh cannot run reliably
 against all specified instances. If an instance is unreachable, the Proxy exits with a failure
 status code.`)
 
-	localFlags.BoolVar(&c.conf.IgnoreFailedConnections, "ignore-failed-connections", false,
-		`If set, the Proxy will not exit on startup when Cloud SQL instances are unreachable.`)
+	localFlags.BoolVar(&c.conf.SkipFailedInstanceConfig, "skip-failed-instance-config", false,
+		`If set, the Proxy will skip any instances that are unreachable (
+only applicable to Unix sockets)`)
 
 	// Global and per instance flags
 	localFlags.StringVarP(&c.conf.Addr, "address", "a", "127.0.0.1",

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -528,7 +528,7 @@ against all specified instances. If an instance is unreachable, the Proxy exits 
 status code.`)
 
 	localFlags.BoolVar(&c.conf.SkipFailedInstanceConfig, "skip-failed-instance-config", false,
-		`If set, the Proxy will skip any instances that are unreachable (
+		`If set, the Proxy will skip any instances that are invalid/unreachable (
 only applicable to Unix sockets)`)
 
 	// Global and per instance flags

--- a/docs/cmd/cloud-sql-proxy.md
+++ b/docs/cmd/cloud-sql-proxy.md
@@ -277,6 +277,8 @@ cloud-sql-proxy INSTANCE_CONNECTION_NAME... [flags]
       --run-connection-test                  Runs a connection test
                                              against all specified instances. If an instance is unreachable, the Proxy exits with a failure
                                              status code.
+      --skip-failed-instance-config          If set, the Proxy will skip any instances that are invalid/unreachable (
+                                             only applicable to Unix sockets)
       --sqladmin-api-endpoint string         API endpoint for all Cloud SQL Admin API requests. (default: https://sqladmin.googleapis.com)
   -l, --structured-logs                      Enable structured logging with LogEntry format
       --telemetry-prefix string              Prefix for Cloud Monitoring metrics.

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -268,9 +268,9 @@ type Config struct {
 	// to all specified instances to verify the network path is valid.
 	RunConnectionTest bool
 
-	// IgnoreFailedConnections determines whether the Proxy should ignore failed
+	// SkipFailedInstanceConfig determines whether the Proxy should ignore failed
 	// connections to Cloud SQL instances instead of exiting on startup.
-	IgnoreFailedConnections bool
+	SkipFailedInstanceConfig bool
 }
 
 // dialOptions interprets appropriate dial options for a particular instance
@@ -550,8 +550,8 @@ func NewClient(ctx context.Context, d cloudsql.Dialer, l cloudsql.Logger, conf *
 	for _, inst := range conf.Instances {
 		m, err := c.newSocketMount(ctx, conf, pc, inst)
 		if err != nil {
-			if conf.IgnoreFailedConnections {
-				l.Errorf("[%v] Unable to mount socket: %v (ignoring due to ignore-failed-connections flag)", inst.Name, err)
+			if conf.SkipFailedInstanceConfig {
+				l.Errorf("[%v] Unable to mount socket: %v (skipped due to skip-failed-instance-config flag)", inst.Name, err)
 				continue
 			}
 

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -268,8 +268,9 @@ type Config struct {
 	// to all specified instances to verify the network path is valid.
 	RunConnectionTest bool
 
-	// SkipFailedInstanceConfig determines whether the Proxy should ignore failed
+	// SkipFailedInstanceConfig determines whether the Proxy should skip failed
 	// connections to Cloud SQL instances instead of exiting on startup.
+	// This only applies to Unix sockets.
 	SkipFailedInstanceConfig bool
 }
 

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -310,6 +310,20 @@ func TestClientInitialization(t *testing.T) {
 			},
 		},
 		{
+			desc: "with Unix socket and two instances, one invalid but skipped",
+			in: &proxy.Config{
+				UnixSocket: testDir,
+				Instances: []proxy.InstanceConnConfig{
+					{Name: pg},
+					{Name: "proj:region:fakeserver"},
+				},
+				SkipFailedInstanceConfig: true,
+			},
+			wantUnixAddrs: []string{
+				filepath.Join(testDir, pg, ".s.PGSQL.5432"),
+			},
+		},
+		{
 			desc: "with TCP port for non functional instance",
 			in: &proxy.Config{
 				Instances: []proxy.InstanceConnConfig{

--- a/migration-guide.md
+++ b/migration-guide.md
@@ -144,29 +144,29 @@ The following table lists in alphabetical order v1 flags and their v2 version.
 - ❌: Not supported in V2
 - 🤔: Unplanned, but has open feature request
 
-| v1                          | v2                    | Notes                                                                                |
-| --------------------------- | --------------------- | ------------------------------------------------------------------------------------ |
-| check_region                | ❌                    |                                                                                      |
-| credential_file             | credentials-file      |                                                                                      |
-| dir                         | unix-socket           |                                                                                      |
-| enable_iam_login            | auto-iam-authn        |                                                                                      |
-| fd_rlimit                   | 🤔                    | [Feature Request](https://github.com/GoogleCloudPlatform/cloudsql-proxy/issues/1258) |
-| fuse                        | fuse                  |                                                                                      |
-| fuse_tmp                    | fuse-temp-dir         |                                                                                      |
-| health_check_port           | http-port             |  Use --http-address=0.0.0.0 when using a health check in Kubernetes                  |
-| host                        | sqladmin-api-endpoint |                                                                                      |
-| instances_metadata          | 🤔                    | [Feature Request](https://github.com/GoogleCloudPlatform/cloudsql-proxy/issues/1259) |
-| ip_address_types            | private-ip            | Defaults to public. To connect to a private IP, you must add the --private-ip flag   |
-| log_debug_stdout            | ❌                    | v2 logs to stdout, errors to stderr by default                                       |
-| max_connections             | max-connections       |                                                                                      |
-| projects                    | ❌                    | v2 prefers explicit connection configuration to avoid user error                     |
-| quiet                       | quiet                 | quiet disables all logging except errors                                             |
-| quota_project               | quota-project         |                                                                                      |
-| refresh_config_throttle     | ❌                    |                                                                                      |
-| skip_failed_instance_config | ❌                    | This flag was only necessary with Unix sockets. Use TCP sockets to avoid failed startup. |
-| structured_logs             | structured-logs       |                                                                                      |
-| term_timeout                | max-sigterm-delay     |                                                                                      |
-| token                       | token                 |                                                                                      |
-| use_http_health_check       | health-check          |                                                                                      |
-| verbose                     | ❌                    |                                                                                      |
-| version                     | version               |                                                                                      |
+| v1                          | v2                          | Notes                                                                                |
+| --------------------------- | --------------------------- | ------------------------------------------------------------------------------------ |
+| check_region                | ❌                          |                                                                                      |
+| credential_file             | credentials-file            |                                                                                      |
+| dir                         | unix-socket                 |                                                                                      |
+| enable_iam_login            | auto-iam-authn              |                                                                                      |
+| fd_rlimit                   | 🤔                          | [Feature Request](https://github.com/GoogleCloudPlatform/cloudsql-proxy/issues/1258) |
+| fuse                        | fuse                        |                                                                                      |
+| fuse_tmp                    | fuse-temp-dir               |                                                                                      |
+| health_check_port           | http-port                   |  Use --http-address=0.0.0.0 when using a health check in Kubernetes                  |
+| host                        | sqladmin-api-endpoint       |                                                                                      |
+| instances_metadata          | 🤔                          | [Feature Request](https://github.com/GoogleCloudPlatform/cloudsql-proxy/issues/1259) |
+| ip_address_types            | private-ip                  | Defaults to public. To connect to a private IP, you must add the --private-ip flag   |
+| log_debug_stdout            | ❌                          | v2 logs to stdout, errors to stderr by default                                       |
+| max_connections             | max-connections             |                                                                                      |
+| projects                    | ❌                          | v2 prefers explicit connection configuration to avoid user error                     |
+| quiet                       | quiet                       | quiet disables all logging except errors                                             |
+| quota_project               | quota-project               |                                                                                      |
+| refresh_config_throttle     | ❌                          |                                                                                      |
+| skip_failed_instance_config | skip-failed-instance-config |                                                                                      |
+| structured_logs             | structured-logs             |                                                                                      |
+| term_timeout                | max-sigterm-delay           |                                                                                      |
+| token                       | token                       |                                                                                      |
+| use_http_health_check       | health-check                |                                                                                      |
+| verbose                     | ❌                          |                                                                                      |
+| version                     | version                     |                                                                                      |


### PR DESCRIPTION
Port `skip-failed-instance-config` from v1 to v2. If set, this will ignore connection errors instead of exiting on startup. See more use case details in associated issue.

fixes https://github.com/GoogleCloudPlatform/cloud-sql-proxy/issues/2451