### PR TITLE
chore: Fix build.sh dependency update script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -165,7 +165,7 @@ function dockerfile_from_deps() {
   else
     echo "Updating docker image to $file to $digest"
     set -x
-    sed -i "" "s/$oldDigest/$digest/g" "$file"
+    sed -ibak -e "s/$oldDigest/$digest/g" "$file"
   fi
 
 }


### PR DESCRIPTION
This fixes an error in`build.sh deps` command. Now the docker container image hashes will be updated correctly. 