### PR TITLE
docs: Update k8s startup port to be on same as liveness port

### DIFF
--- a/examples/k8s-health-check/README.md
+++ b/examples/k8s-health-check/README.md
@@ -43,7 +43,7 @@ startupProbe:
    # the pod only after the proxy has successfully started.
    httpGet:
       path: /startup
-      port: 9090
+      port: 9801
    periodSeconds: 1
    timeoutSeconds: 5
    failureThreshold: 20


### PR DESCRIPTION
## What

This PR resolves #2473 .

> It feels very unlikely that the /startup and /liveness routes are on different ports, but in the example one is referring to 9090 and the other 9801.
> ...
> I expect this is probably a typo and the ports should be the same.