### PR TITLE
chore: add release-please tags to generated docs

### DIFF
--- a/cmd/gendocs/gen_cloud-sql-proxy_docs.go
+++ b/cmd/gendocs/gen_cloud-sql-proxy_docs.go
@@ -15,9 +15,12 @@
 package main
 
 import (
+	"bufio"
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 
 	"github.com/GoogleCloudPlatform/cloud-sql-proxy/v2/cmd"
 	"github.com/spf13/cobra/doc"
@@ -48,4 +51,40 @@ func main() {
 	cloudSQLProxy.Execute()
 	cloudSQLProxy.DisableAutoGenTag = true
 	doc.GenMarkdownTree(cloudSQLProxy.Command, outDir)
+
+	// Edit the Markdown file to add release-please tags around the lines that contain
+	// the version number:
+	//
+	// <!-- {x-release-please-start-version} -->
+	// https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy/v2.20.0/third_party/licenses.tar.gz
+	// <!-- {x-release-please-end} -->
+
+	f := filepath.Join(outDir, "cloud-sql-proxy.md")
+	b, err := os.ReadFile(f)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to read file: %v\n", err)
+		os.Exit(1)
+	}
+
+	var out bytes.Buffer
+	sc := bufio.NewScanner(bytes.NewReader(b))
+	// Example: https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy/v2.20.0/third_party/licenses.tar.gz
+	re := regexp.MustCompile(`cloud-sql-connectors/cloud-sql-proxy/v\d+\.\d+\.\d+\b/`)
+	for sc.Scan() {
+		line := sc.Bytes()
+		if re.Match(line) {
+			out.WriteString("<!-- {x-release-please-start-version} -->\n")
+			out.Write(line)
+			out.WriteString("\n")
+			out.WriteString("<!-- {x-release-please-end} -->\n")
+		} else {
+			out.Write(line)
+			out.WriteString("\n")
+		}
+	}
+
+	if err := os.WriteFile(f, out.Bytes(), 0644); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to write file: %v\n", err)
+		os.Exit(1)
+	}
 }

--- a/docs/cmd/cloud-sql-proxy.md
+++ b/docs/cmd/cloud-sql-proxy.md
@@ -218,7 +218,9 @@ Third Party Licenses
   To view all licenses for third party dependencies used within this
   distribution please see:
 
+<!-- {x-release-please-start-version} -->
   https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy/v2.25.0/third_party/licenses.tar.gz 
+<!-- {x-release-please-end} -->
 
 
 ```


### PR DESCRIPTION
Adds a step to the doc generation to include release-please tags. This allows release-please to automatically update the version in the generated documentation.