### PR TITLE
fix: Correctly set the credentials token source and the WithIAMAuthN opt

### DIFF
--- a/tests/postgres_test.go
+++ b/tests/postgres_test.go
@@ -280,6 +280,14 @@ func TestPostgresIAMDBAuthn(t *testing.T) {
 			dsn: fmt.Sprintf("host=localhost user=%s database=%s sslmode=disable",
 				impersonatedIAMUser, *postgresDB),
 		},
+		{
+			desc: "using impersonation with query param",
+			args: []string{
+				"--impersonate-service-account", *impersonatedUser,
+				fmt.Sprintf("%s?auto-iam-authn=true", *postgresConnName)},
+			dsn: fmt.Sprintf("host=localhost user=%s password=password database=%s sslmode=disable",
+				impersonatedIAMUser, *postgresDB),
+		},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.desc, func(t *testing.T) {


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/cloud-sql-proxy/issues/2542
Replaces https://github.com/GoogleCloudPlatform/cloud-sql-proxy/pull/2543

Additional to https://github.com/GoogleCloudPlatform/cloud-sql-proxy/pull/2543: Test (fails without the code change) and setting options was missing.