### PR TITLE
fix: Set the universe domain when using an impersonation chain.

### DIFF
--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -342,6 +342,9 @@ func credentialsOpt(c Config, l cloudsql.Logger) (cloudsqlconn.Option, error) {
 	// credentials token source.
 	if c.ImpersonationChain != "" {
 		var iopts []option.ClientOption
+		if c.UniverseDomain != "" {
+			iopts = append(iopts, option.WithUniverseDomain(c.UniverseDomain))
+		}
 		switch {
 		case c.Token != "":
 			l.Infof("Impersonating service account with OAuth2 token")


### PR DESCRIPTION
When the proxy is configured with both a universe domain AND an impersonation chain, the impersonation token source must be configured with the universe domain.