### PR TITLE
docs: Update proxy_with_workload_identity.yaml

### DIFF
--- a/examples/k8s-sidecar/proxy_with_workload_identity.yaml
+++ b/examples/k8s-sidecar/proxy_with_workload_identity.yaml
@@ -55,7 +55,7 @@ spec:
           restartPolicy: Always
           # It is recommended to use the latest version of the Cloud SQL Auth Proxy
           # Make sure to update on a regular schedule!
-          image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.14.1
+          image: us-docker.pkg.dev/cloudsql-proxy/cloud-sql-proxy
           args:
             # If connecting from a VPC-native GKE cluster, you can use the
             # following flag to have the proxy connect over private IP


### PR DESCRIPTION
Replacing GCR (deprecated) image with AR image. This will fix a documentation bug related to the GCR image appearing in https://docs.cloud.google.com/sql/docs/mysql/connect-kubernetes-engine#run_the_in_a_sidecar_pattern.