### PR TITLE
feat: Add PSC DNS and Global Write Endpoint support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/GoogleCloudPlatform/cloud-sql-proxy/v2
 go 1.25.8
 
 require (
-	cloud.google.com/go/cloudsqlconn v1.22.1
+	cloud.google.com/go/cloudsqlconn v1.23.0
 	contrib.go.opencensus.io/exporter/prometheus v0.4.2
 	contrib.go.opencensus.io/exporter/stackdriver v0.13.14
 	github.com/coreos/go-systemd/v22 v22.7.0

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,8 @@ cloud.google.com/go/bigquery v1.4.0/go.mod h1:S8dzgnTigyfTmLBfrtrhyYhwRxG72rYxvf
 cloud.google.com/go/bigquery v1.5.0/go.mod h1:snEHRnqQbz117VIFhE8bmtwIDY80NLUZUMb4Nv6dBIg=
 cloud.google.com/go/bigquery v1.7.0/go.mod h1://okPTzCYNXSlb24MZs83e2Do+h+VXtc4gLoIoXIAPc=
 cloud.google.com/go/bigquery v1.8.0/go.mod h1:J5hqkt3O0uAFnINi6JXValWIb1v0goeZM77hZzJN/fQ=
-cloud.google.com/go/cloudsqlconn v1.22.1 h1:c4HkWMSV4pDL8kJid+nIuF+6iE07pR5Mn/sRVY17wf4=
-cloud.google.com/go/cloudsqlconn v1.22.1/go.mod h1:p7l+u0ThOzSvC5a4fkywi1hEyD8S709X1zEqux9tsq0=
+cloud.google.com/go/cloudsqlconn v1.23.0 h1:zc/BcLVPUKQKXPkfAFgmnAzd0wL6aQuLWOLFfK9ywS4=
+cloud.google.com/go/cloudsqlconn v1.23.0/go.mod h1:NS1CEi6zVhrSSK1ZQ1AYqWqrzoYR89jhSaElU9JHaNI=
 cloud.google.com/go/compute/metadata v0.9.0 h1:pDUj4QMoPejqq20dK0Pg2N4yG9zIkYGdBtwLoEkH9Zs=
 cloud.google.com/go/compute/metadata v0.9.0/go.mod h1:E0bWwX5wTnLPedCKqk3pJmVgCBSM6qQI1yTBdEb3C10=
 cloud.google.com/go/datastore v1.0.0/go.mod h1:LXYbyblFSglQ5pkeyhO+Qmw7ukd3C+pD7TKLgZqpHYE=


### PR DESCRIPTION
This incorporates the new version of the go connector with support for  PSC DNS and Global Write Endpoints. 

See https://github.com/GoogleCloudPlatform/cloud-sql-go-connector/pull/1106