### PR TITLE
proxy cooldown resource exhausted

### DIFF
--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -874,7 +874,7 @@ func TestNewCommandWithEnvironmentConfig(t *testing.T) {
 			want: withDefaults(&proxy.Config{
 				SQLDataEndpoint: "https://test.googleapis.com",
 			}),
-		}
+		},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.desc, func(t *testing.T) {
@@ -1087,54 +1087,6 @@ func TestPSCQueryParams(t *testing.T) {
 	}
 }
 
-func TestSQLDataQueryParams(t *testing.T) {
-	tcs := []struct {
-		desc string
-		args []string
-		want *bool
-	}{
-		{
-			desc: "when the query string is absent",
-			args: []string{"proj:region:inst"},
-			want: nil,
-		},
-		{
-			desc: "when the query string is true",
-			args: []string{"proj:region:inst?sql-data=true"},
-			want: pointer(true),
-		},
-		{
-			desc: "when the query string is false",
-			args: []string{"proj:region:inst?sql-data=false"},
-			want: pointer(false),
-		},
-	}
-	for _, tc := range tcs {
-		t.Run(tc.desc, func(t *testing.T) {
-			c, err := invokeProxyCommand(tc.args)
-			if err != nil {
-				t.Fatalf("command.Execute: %v", err)
-			}
-			if tc.want == nil {
-				if len(c.conf.Instances) > 0 && c.conf.Instances[0].SQLDataEnabled != nil {
-					t.Fatalf("args = %v, want nil, got = %v", tc.args, *c.conf.Instances[0].SQLDataEnabled)
-				}
-				return
-			}
-			if len(c.conf.Instances) == 0 {
-				t.Fatal("expected at least one instance")
-			}
-			got := c.conf.Instances[0].SQLDataEnabled
-			if got == nil {
-				t.Fatalf("args = %v, want = %v, got = nil", tc.args, *tc.want)
-			}
-			if *got != *tc.want {
-				t.Errorf("args = %v, want = %v, got = %v", tc.args, *tc.want, *got)
-			}
-		})
-	}
-}
-
 func TestNewCommandWithErrors(t *testing.T) {
 	tcs := []struct {
 		desc string
@@ -1253,14 +1205,6 @@ func TestNewCommandWithErrors(t *testing.T) {
 		{
 			desc: "when the iam authn login query param contains multiple values",
 			args: []string{"proj:region:inst?auto-iam-authn=true&auto-iam-authn=false"},
-		},
-		{
-			desc: "when the sql-data query param contains multiple values",
-			args: []string{"proj:region:inst?sql-data=true&sql-data=false"},
-		},
-		{
-			desc: "when the sql-data query param is bogus",
-			args: []string{"proj:region:inst?sql-data=nope"},
 		},
 		{
 			desc: "when the iam authn login query param is bogus",

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -495,7 +495,7 @@ func TestNewCommandArguments(t *testing.T) {
 					SQLDataEnabled: pointer(true),
 				}},
 			}),
-		},
+		}
 	}
 
 	for _, tc := range tcs {
@@ -874,7 +874,7 @@ func TestNewCommandWithEnvironmentConfig(t *testing.T) {
 			want: withDefaults(&proxy.Config{
 				SQLDataEndpoint: "https://test.googleapis.com",
 			}),
-		},
+		}
 	}
 	for _, tc := range tcs {
 		t.Run(tc.desc, func(t *testing.T) {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -495,7 +495,7 @@ func TestNewCommandArguments(t *testing.T) {
 					SQLDataEnabled: pointer(true),
 				}},
 			}),
-		}
+		},
 	}
 
 	for _, tc := range tcs {

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/census-instrumentation/opencensus-proto v0.4.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.7 // indirect
-	github.com/felixge/httpsnoop v1.0.4 // indirect
+	github.com/felixge/httpsnoop v1.1.0 // indirect
 	github.com/fsnotify/fsnotify v1.10.1 // indirect
 	github.com/go-logr/logr v1.4.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
@@ -78,7 +78,6 @@ require (
 	golang.org/x/net v0.57.0 // indirect
 	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/text v0.40.0 // indirect
-	golang.org/x/crypto v0.53.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 	google.golang.org/genproto v0.0.0-20260720211330-0afa2a65878a // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260720211330-0afa2a65878a // indirect

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/census-instrumentation/opencensus-proto v0.4.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.7 // indirect
-	github.com/felixge/httpsnoop v1.1.0 // indirect
+	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.10.1 // indirect
 	github.com/go-logr/logr v1.4.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
@@ -78,6 +78,7 @@ require (
 	golang.org/x/net v0.57.0 // indirect
 	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/text v0.40.0 // indirect
+	golang.org/x/crypto v0.53.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 	google.golang.org/genproto v0.0.0-20260720211330-0afa2a65878a // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260720211330-0afa2a65878a // indirect

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -16,6 +16,7 @@ package proxy
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -28,6 +29,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/cloudsqlconn"
+	"cloud.google.com/go/cloudsqlconn/errtype"
 	"github.com/GoogleCloudPlatform/cloud-sql-proxy/v2/cloudsql"
 	"github.com/GoogleCloudPlatform/cloud-sql-proxy/v2/internal/gcloud"
 	"golang.org/x/oauth2"
@@ -95,6 +97,8 @@ type InstanceConnConfig struct {
 	// necessary. If set, UnixSocketPath takes precedence over UnixSocket, Addr
 	// and Port.
 	UnixSocketPath string
+	// SQLDataEnabled enables connections through the SqlDataService for this connection.
+	SQLDataEnabled *bool
 	// IAMAuthN enables automatic IAM DB Authentication for the instance.
 	// MySQL and Postgres only. If it is nil, the value was not specified.
 	IAMAuthN *bool
@@ -200,6 +204,11 @@ type Config struct {
 	// of a request context, e.g., Cloud Run.
 	LazyRefresh bool
 
+	// SQLDataEnabled configures the dialer to use the SQL Data API.
+	SQLDataEnabled bool
+	// SQLDataEndpoint configures the endpoint of the SQL Data service.
+	SQLDataEndpoint string
+
 	// Instances are configuration for individual instances. Instance
 	// configuration takes precedence over global configuration.
 	Instances []InstanceConnConfig
@@ -281,6 +290,9 @@ func dialOptions(c Config, i InstanceConnConfig) []cloudsqlconn.DialOption {
 
 	if i.IAMAuthN != nil {
 		opts = append(opts, cloudsqlconn.WithDialIAMAuthN(*i.IAMAuthN))
+	}
+	if i.SQLDataEnabled != nil && *i.SQLDataEnabled || c.SQLDataEnabled {
+		opts = append(opts, cloudsqlconn.WithSQLData())
 	}
 
 	switch {
@@ -469,6 +481,10 @@ func (c *Config) DialerOptions(l cloudsql.Logger) ([]cloudsqlconn.Option, error)
 		opts = append(opts, cloudsqlconn.WithLazyRefresh())
 	}
 
+	if c.SQLDataEndpoint != "" {
+		opts = append(opts, cloudsqlconn.WithSQLDataEndpoint(c.SQLDataEndpoint))
+	}
+
 	return opts, nil
 }
 
@@ -564,8 +580,12 @@ func NewClient(ctx context.Context, d cloudsql.Dialer, l cloudsql.Logger, conf *
 		return configureFUSE(c, conf)
 	}
 
+	// unless the proxy is in SqlDataEnabled mode, initiate a refresh operation to warm the cache
 	for _, inst := range conf.Instances {
-		// Initiate refresh operation and warm the cache.
+		// Skip instances with SqlDataEnabled
+		if conf.SQLDataEnabled || inst.SQLDataEnabled != nil && *inst.SQLDataEnabled {
+			continue
+		}
 		go func(name string) { _, _ = d.EngineVersion(ctx, name) }(inst.Name)
 	}
 
@@ -803,7 +823,12 @@ func (c *Client) serveSocketMount(_ context.Context, s *socketMount) error {
 
 			sConn, err := c.dialer.Dial(ctx, s.inst, s.dialOpts...)
 			if err != nil {
-				c.logger.Errorf("[%s] failed to connect to instance: %v", s.inst, err)
+				var reErr *errtype.ResourceExhaustedError
+				if errors.As(err, &reErr) {
+					c.logger.Errorf("[%s] failed to connect to instance (resource exhausted): %v", s.inst, err)
+				} else {
+					c.logger.Errorf("[%s] failed to connect to instance: %v", s.inst, err)
+				}
 				_ = cConn.Close()
 				return
 			}
@@ -852,6 +877,13 @@ func (c *Client) newSocketMount(ctx context.Context, conf *Config, pc *portConfi
 		if inst.Addr != "" {
 			a = inst.Addr
 		}
+		if ip := net.ParseIP(a); ip != nil {
+			if ip.To4() != nil {
+				network = "tcp4"
+			} else {
+				network = "tcp6"
+			}
+		}
 
 		var np int
 		switch {
@@ -877,10 +909,17 @@ func (c *Client) newSocketMount(ctx context.Context, conf *Config, pc *portConfi
 	} else {
 		network = "unix"
 
-		version, err := c.dialer.EngineVersion(ctx, inst.Name)
-		if err != nil {
-			c.logger.Errorf("[%v] could not resolve instance version: %v", inst.Name, err)
-			return nil, err
+		var version string
+		switch {
+		case conf.SQLDataEnabled || inst.SQLDataEnabled != nil && *inst.SQLDataEnabled:
+			version = "POSTGRES"
+		default:
+			var err error
+			version, err = c.dialer.EngineVersion(ctx, inst.Name)
+			if err != nil {
+				c.logger.Errorf("[%v] could not resolve instance version: %v", inst.Name, err)
+				return nil, err
+			}
 		}
 
 		address, err = newUnixSocketMount(inst, conf.UnixSocket, strings.HasPrefix(version, "POSTGRES"))

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -95,8 +95,6 @@ type InstanceConnConfig struct {
 	// necessary. If set, UnixSocketPath takes precedence over UnixSocket, Addr
 	// and Port.
 	UnixSocketPath string
-	// SQLDataEnabled enables connections through the SqlDataService for this connection.
-	SQLDataEnabled *bool
 	// IAMAuthN enables automatic IAM DB Authentication for the instance.
 	// MySQL and Postgres only. If it is nil, the value was not specified.
 	IAMAuthN *bool
@@ -202,11 +200,6 @@ type Config struct {
 	// of a request context, e.g., Cloud Run.
 	LazyRefresh bool
 
-	// SQLDataEnabled configures the dialer to use the SQL Data API.
-	SQLDataEnabled bool
-	// SQLDataEndpoint configures the endpoint of the SQL Data service.
-	SQLDataEndpoint string
-
 	// Instances are configuration for individual instances. Instance
 	// configuration takes precedence over global configuration.
 	Instances []InstanceConnConfig
@@ -288,9 +281,6 @@ func dialOptions(c Config, i InstanceConnConfig) []cloudsqlconn.DialOption {
 
 	if i.IAMAuthN != nil {
 		opts = append(opts, cloudsqlconn.WithDialIAMAuthN(*i.IAMAuthN))
-	}
-	if i.SQLDataEnabled != nil && *i.SQLDataEnabled || c.SQLDataEnabled {
-		opts = append(opts, cloudsqlconn.WithSQLData())
 	}
 
 	switch {
@@ -479,10 +469,6 @@ func (c *Config) DialerOptions(l cloudsql.Logger) ([]cloudsqlconn.Option, error)
 		opts = append(opts, cloudsqlconn.WithLazyRefresh())
 	}
 
-	if c.SQLDataEndpoint != "" {
-		opts = append(opts, cloudsqlconn.WithSQLDataEndpoint(c.SQLDataEndpoint))
-	}
-
 	return opts, nil
 }
 
@@ -578,12 +564,8 @@ func NewClient(ctx context.Context, d cloudsql.Dialer, l cloudsql.Logger, conf *
 		return configureFUSE(c, conf)
 	}
 
-	// unless the proxy is in SqlDataEnabled mode, initiate a refresh operation to warm the cache
 	for _, inst := range conf.Instances {
-		// Skip instances with SqlDataEnabled
-		if conf.SQLDataEnabled || inst.SQLDataEnabled != nil && *inst.SQLDataEnabled {
-			continue
-		}
+		// Initiate refresh operation and warm the cache.
 		go func(name string) { _, _ = d.EngineVersion(ctx, name) }(inst.Name)
 	}
 
@@ -870,13 +852,6 @@ func (c *Client) newSocketMount(ctx context.Context, conf *Config, pc *portConfi
 		if inst.Addr != "" {
 			a = inst.Addr
 		}
-		if ip := net.ParseIP(a); ip != nil {
-			if ip.To4() != nil {
-				network = "tcp4"
-			} else {
-				network = "tcp6"
-			}
-		}
 
 		var np int
 		switch {
@@ -902,17 +877,10 @@ func (c *Client) newSocketMount(ctx context.Context, conf *Config, pc *portConfi
 	} else {
 		network = "unix"
 
-		var version string
-		switch {
-		case conf.SQLDataEnabled || inst.SQLDataEnabled != nil && *inst.SQLDataEnabled:
-			version = "POSTGRES"
-		default:
-			var err error
-			version, err = c.dialer.EngineVersion(ctx, inst.Name)
-			if err != nil {
-				c.logger.Errorf("[%v] could not resolve instance version: %v", inst.Name, err)
-				return nil, err
-			}
+		version, err := c.dialer.EngineVersion(ctx, inst.Name)
+		if err != nil {
+			c.logger.Errorf("[%v] could not resolve instance version: %v", inst.Name, err)
+			return nil, err
 		}
 
 		address, err = newUnixSocketMount(inst, conf.UnixSocket, strings.HasPrefix(version, "POSTGRES"))

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -108,7 +108,11 @@ func (*errorDialer) Close() error {
 }
 
 func createTempDir(t *testing.T) (string, func()) {
-	testDir, err := os.MkdirTemp("", "*")
+	var dir string
+	if os.PathSeparator == '/' {
+		dir = "/tmp"
+	}
+	testDir, err := os.MkdirTemp(dir, "sqlproxy*")
 	if err != nil {
 		t.Fatalf("failed to create temp dir: %v", err)
 	}

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -15,6 +15,7 @@
 package proxy_test
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -29,6 +30,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/cloudsqlconn"
+	"cloud.google.com/go/cloudsqlconn/errtype"
 	"github.com/GoogleCloudPlatform/cloud-sql-proxy/v2/internal/log"
 	"github.com/GoogleCloudPlatform/cloud-sql-proxy/v2/internal/proxy"
 )
@@ -942,5 +944,63 @@ func TestProxyMultiInstances(t *testing.T) {
 				t.Fatalf("want return = %v, got = %v", tc.wantSuccess, err == nil)
 			}
 		})
+	}
+}
+
+type resourceExhaustedDialer struct {
+	fakeDialer
+}
+
+func (*resourceExhaustedDialer) Dial(_ context.Context, inst string, _ ...cloudsqlconn.DialOption) (net.Conn, error) {
+	return nil, errtype.NewResourceExhaustedError("simulated resource exhausted", inst, nil)
+}
+
+type safeBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (s *safeBuffer) Write(p []byte) (n int, err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.Write(p)
+}
+
+func (s *safeBuffer) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.String()
+}
+
+func TestResourceExhaustedCooldownLog(t *testing.T) {
+	in := &proxy.Config{
+		Addr: "127.0.0.1",
+		Port: 24020,
+		Instances: []proxy.InstanceConnConfig{
+			{Name: "proj:reg:inst"},
+		},
+	}
+	var buf safeBuffer
+	logger := log.NewStdLogger(io.Discard, &buf)
+
+	c, err := proxy.NewClient(context.Background(), &resourceExhaustedDialer{}, logger, in, nil)
+	if err != nil {
+		t.Fatalf("proxy.NewClient error want = nil, got = %v", err)
+	}
+	go c.Serve(context.Background(), func() {})
+	defer c.Close()
+
+	conn, err := net.Dial("tcp", "127.0.0.1:24020")
+	if err != nil {
+		t.Fatalf("failed to dial proxy: %v", err)
+	}
+	defer conn.Close()
+
+	time.Sleep(100 * time.Millisecond)
+
+	output := buf.String()
+	want := "failed to connect to instance (resource exhausted)"
+	if !strings.Contains(output, want) {
+		t.Errorf("log output mismatch: got %q, want to contain %q", output, want)
 	}
 }

--- a/tests/postgres_test.go
+++ b/tests/postgres_test.go
@@ -350,3 +350,31 @@ func TestPostgresHealthCheck(t *testing.T) {
 	}
 	testHealthCheck(t, *postgresConnName)
 }
+
+func TestPostgresAIDeveloper(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping Postgres integration tests")
+	}
+	pass := os.Getenv("POSTGRES_CUSTOMER_CAS_PASS")
+	if pass == "" {
+		t.Fatal("'POSTGRES_CUSTOMER_CAS_PASS' env var not set")
+	}
+
+	const connName = "hessjc-playground-01:us-central1:aide-poc-instance-1"
+	const user = "postgres"
+	const dbName = "postgres"
+	const quotaProj = "hessjc-playground-01"
+
+	dsn := fmt.Sprintf("host=localhost user=%s password=%s database=%s sslmode=disable",
+		user, pass, dbName)
+
+	args := []string{
+		"--sqladmin-api-endpoint", "https://coreltest-sqladmin.mtls.sandbox.googleapis.com",
+		"--sql-data-endpoint", "coreltest-sqladmin.mtls.sandbox.googleapis.com:443",
+		"--sql-data",
+		"--quota-project", quotaProj,
+		connName,
+	}
+
+	proxyConnTest(t, args, "pgx", dsn)
+}

--- a/tests/postgres_test.go
+++ b/tests/postgres_test.go
@@ -115,7 +115,11 @@ func TestPostgresMCPUnix(t *testing.T) {
 }
 
 func createTempDir(t *testing.T) (string, func()) {
-	testDir, err := os.MkdirTemp("", "*")
+	var dir string
+	if os.PathSeparator == '/' {
+		dir = "/tmp"
+	}
+	testDir, err := os.MkdirTemp(dir, "sqlproxy*")
 	if err != nil {
 		t.Fatalf("failed to create temp dir: %v", err)
 	}


### PR DESCRIPTION
- **build: support metadata, junit reports, and IAM helpers in build.sh**
- **feat: Support AI Developer Edition connections through the Cloud SQL Auth Proxy**
- **Internal changes to skip fuse on Kokoro tests.**
- **Update cloud-sql-go-connector to v1.22.0 and add --sql-data-endpoint alias**
- **Fix code review issues.**
- **test(proxy): use /tmp for Unix socket tests to avoid long paths in Kokoro**
- **feat: Add local E2E test for AI Developer Edition in proxy**
- **feat: log warning on ResourceExhausted errors**
