### PR TITLE
fix: Ensure that the SqlDataEndpoint includes the default port :443

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/GoogleCloudPlatform/cloud-sql-proxy/v2
 go 1.25.8
 
 require (
-	cloud.google.com/go/cloudsqlconn v1.25.0
+	cloud.google.com/go/cloudsqlconn v1.25.1
 	contrib.go.opencensus.io/exporter/prometheus v0.4.2
 	contrib.go.opencensus.io/exporter/stackdriver v0.13.14
 	github.com/coreos/go-systemd/v22 v22.7.0

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,8 @@ cloud.google.com/go/bigquery v1.4.0/go.mod h1:S8dzgnTigyfTmLBfrtrhyYhwRxG72rYxvf
 cloud.google.com/go/bigquery v1.5.0/go.mod h1:snEHRnqQbz117VIFhE8bmtwIDY80NLUZUMb4Nv6dBIg=
 cloud.google.com/go/bigquery v1.7.0/go.mod h1://okPTzCYNXSlb24MZs83e2Do+h+VXtc4gLoIoXIAPc=
 cloud.google.com/go/bigquery v1.8.0/go.mod h1:J5hqkt3O0uAFnINi6JXValWIb1v0goeZM77hZzJN/fQ=
-cloud.google.com/go/cloudsqlconn v1.25.0 h1:nh0OHrWTsCMoQL0yV4Ns6/REYY8NRAylPzOBemh7k+Y=
-cloud.google.com/go/cloudsqlconn v1.25.0/go.mod h1:yBjHpKuIGsmVTrqgMqfAvs1o3V0f8ee+wCiCkM61UjI=
+cloud.google.com/go/cloudsqlconn v1.25.1 h1:NSm9zyFySRjFivbOSGi0Mv5VS59SNel7OnWkkMmKUa8=
+cloud.google.com/go/cloudsqlconn v1.25.1/go.mod h1:yBjHpKuIGsmVTrqgMqfAvs1o3V0f8ee+wCiCkM61UjI=
 cloud.google.com/go/compute/metadata v0.9.0 h1:pDUj4QMoPejqq20dK0Pg2N4yG9zIkYGdBtwLoEkH9Zs=
 cloud.google.com/go/compute/metadata v0.9.0/go.mod h1:E0bWwX5wTnLPedCKqk3pJmVgCBSM6qQI1yTBdEb3C10=
 cloud.google.com/go/datastore v1.0.0/go.mod h1:LXYbyblFSglQ5pkeyhO+Qmw7ukd3C+pD7TKLgZqpHYE=


### PR DESCRIPTION
This incorporates the fix in https://github.com/GoogleCloudPlatform/cloud-sql-go-connector/pull/1148 which was 
released in go connector v1.25.1